### PR TITLE
Classifier with un-managed labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ manager_image_patch.yaml-e
 manager_pull_policy.yaml-e
 
 version.txt
+
+.dockerignore

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -30,6 +30,7 @@ var (
 	RequeueClassifierForCluster            = (*ClassifierReconciler).requeueClassifierForCluster
 	RequeueClassifierForMachine            = (*ClassifierReconciler).requeueClassifierForMachine
 	RequeueClassifierForClassifierReport   = (*ClassifierReconciler).requeueClassifierForClassifierReport
+	RequeueClassifierForClassifier         = (*ClassifierReconciler).requeueClassifierForClassifier
 	GetListOfClusters                      = (*ClassifierReconciler).getListOfClusters
 	UpdateMatchingClustersAndRegistrations = (*ClassifierReconciler).updateMatchingClustersAndRegistrations
 	UpdateLabelsOnMatchingClusters         = (*ClassifierReconciler).updateLabelsOnMatchingClusters


### PR DESCRIPTION
ClassifierReconciler watches for other Classifier instance changes. When a Classifier is deleted and/or list of per cluster labels (considering both managed and unmanaged) changes, requeue all existing Classifier with at least one un-managed label.