### PR TITLE
Fix an issue with multiple clusters matching

### DIFF
--- a/controllers/classifier_controller.go
+++ b/controllers/classifier_controller.go
@@ -473,6 +473,7 @@ func (r *ClassifierReconciler) updateMatchingClustersAndRegistrations(ctx contex
 				ManagedLabels:   tmpManaged,
 				UnManagedLabels: tmpUnmanaged,
 			}
+		i++
 	}
 
 	r.updateClassifierSet(classifierScope, unManaged != 0)
@@ -599,11 +600,7 @@ func (r *ClassifierReconciler) removeAllRegistrations(ctx context.Context,
 
 	for i := range classifierScope.Classifier.Status.MachingClusterStatuses {
 		c := &classifierScope.Classifier.Status.MachingClusterStatuses[i].ClusterRef
-		clusterType := libsveltosv1alpha1.ClusterTypeCapi
-		if c.GetObjectKind().GroupVersionKind().Kind == libsveltosv1alpha1.SveltosClusterKind {
-			clusterType = libsveltosv1alpha1.ClusterTypeCapi
-		}
-		manager.RemoveAllRegistrations(classifierScope.Classifier, c.Namespace, c.Name, clusterType)
+		manager.RemoveAllRegistrations(classifierScope.Classifier, c.Namespace, c.Name, getClusterType(c))
 	}
 
 	return nil

--- a/controllers/classifier_controller_test.go
+++ b/controllers/classifier_controller_test.go
@@ -395,7 +395,7 @@ var _ = Describe("ClusterProfile: Reconciler", func() {
 					Namespace:  clusterNamespace,
 					Name:       clusterName,
 					Kind:       clusterKind,
-					APIVersion: clusterv1.GroupVersion.Group,
+					APIVersion: clusterv1.GroupVersion.String(),
 				},
 				ManagedLabels: []string{label},
 			},


### PR DESCRIPTION
When multiple clusters matches a Classifier, all are supposed to be reported in the Classifier Status. This PR fixes a bug when creating MachingClusterStatuses