### PR TITLE
Deploy DebuggingConfiguration CRD

### DIFF
--- a/controllers/classifier_deployer_test.go
+++ b/controllers/classifier_deployer_test.go
@@ -115,6 +115,27 @@ var _ = Describe("Classifier Deployer", func() {
 		Expect(c.Get(context.TODO(), types.NamespacedName{Name: classifier.Name}, currentClassifier)).To(Succeed())
 	})
 
+	It("deployDebuggingConfigurationCRD deploys DebuggingConfiguration CRD", func() {
+		Expect(controllers.DeployDebuggingConfigurationCRD(context.TODO(), testEnv.Config, klogr.New())).To(Succeed())
+
+		// Eventual loop so testEnv Cache is synced
+		Eventually(func() error {
+			dcCRD := &apiextensionsv1.CustomResourceDefinition{}
+			return testEnv.Get(context.TODO(),
+				types.NamespacedName{Name: "debuggingconfigurations.lib.projectsveltos.io"}, dcCRD)
+		}, timeout, pollingInterval).Should(BeNil())
+	})
+
+	It("deployClassifierInstance creates Classifier instance", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		classifier := getClassifierInstance(randomString())
+		Expect(controllers.DeployClassifierInstance(ctx, c, classifier, klogr.New())).To(Succeed())
+
+		currentClassifier := &libsveltosv1alpha1.Classifier{}
+		Expect(c.Get(context.TODO(), types.NamespacedName{Name: classifier.Name}, currentClassifier)).To(Succeed())
+	})
+
 	It("deployClassifierInstance updates Classifier instance", func() {
 		classifier := getClassifierInstance(randomString())
 

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -19,6 +19,7 @@ package controllers
 var (
 	DeployClassifierCRD                 = deployClassifierCRD
 	DeployClassifierReportCRD           = deployClassifierReportCRD
+	DeployDebuggingConfigurationCRD     = deployDebuggingConfigurationCRD
 	DeployClassifierInstance            = deployClassifierInstance
 	DeployClassifierAgent               = deployClassifierAgent
 	ClassifierHash                      = classifierHash


### PR DESCRIPTION
Classifier agent requires DebuggingConfiguration CRD to be present. As part of deploying classifier agent, adds deployment of debuggingconfiguration CRD.