### PR TITLE
Set annotation not label

### DIFF
--- a/controllers/classifier_deployer.go
+++ b/controllers/classifier_deployer.go
@@ -1024,7 +1024,7 @@ func deployClassifierInstance(ctx context.Context, remoteClient client.Client,
 			toDeployClassifier := &libsveltosv1alpha1.Classifier{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: classifier.Name,
-					Labels: map[string]string{
+					Annotations: map[string]string{
 						libsveltosv1alpha1.DeployedBySveltosAnnotation: "true",
 					},
 				},
@@ -1036,7 +1036,9 @@ func deployClassifierInstance(ctx context.Context, remoteClient client.Client,
 	}
 
 	currentClassifier.Spec = classifier.Spec
-
+	currentClassifier.Annotations = map[string]string{
+		libsveltosv1alpha1.DeployedBySveltosAnnotation: "true",
+	}
 	return remoteClient.Update(ctx, currentClassifier)
 }
 


### PR DESCRIPTION
Classifier is supposed to set Annotation on each classifier instance deployed in managed cluster.

This PR fixes this issue (Classifier was incorrectly setting label)