### PR TITLE
Ignore classifierReport created in mgmt cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/classifier-amd64:main
+      - image: projectsveltos/classifier-amd64:dev
         name: manager

--- a/controllers/classifier_controller.go
+++ b/controllers/classifier_controller.go
@@ -439,6 +439,16 @@ func (r *ClassifierReconciler) updateMatchingClustersAndRegistrations(ctx contex
 	currentMatchingClusters := make(map[corev1.ObjectReference]bool)
 	for i := range classifierReportList.Items {
 		report := &classifierReportList.Items[i]
+		// If Sveltos is managing the management cluster as well,
+		// there will be two types of ClassifierReports:
+		// 1. created by sveltos-agent running in the management cluster.
+		// Those will have Spec.ClusterNamespace not set
+		// 2. pulled by classifier or pushed by sveltos-agent running
+		// in the managed cluster. Those will have Spec.ClusterNamespace set
+		// Consider only type #2
+		if report.Spec.ClusterNamespace == "" {
+			continue
+		}
 		if report.Spec.Match {
 			cluster := getClusterRefFromClassifierReport(report)
 			l := logger.WithValues("cluster", fmt.Sprintf("type: %s cluster %s/%s", report.Spec.ClusterType, cluster.Namespace, cluster.Name))

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -319,7 +319,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/classifier-amd64:main
+        image: projectsveltos/classifier-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Sveltos can be used to manage the management cluster as well. Simply registers the management as SveltosCluster.

In such scenarios there are two types of ClassifierReports found in the management cluster:
1. ClassifierReports created by the sveltos-agent running in the management clusters. Such ClassifierReports have no cluster info in Spec
2. ClassifierReports coming from other managed clusters. Those are either pulled by classifier or pushed by sveltos-agents. Those ClassifierReports have cluster information in the spec section.

When classifier processes ClassifierReports to understand matching clusters, it must exclude ClassifierReports of the first type.