### PR TITLE
sveltos-agent resources in management cluster

### DIFF
--- a/controllers/classifier_deployer.go
+++ b/controllers/classifier_deployer.go
@@ -1303,6 +1303,7 @@ func getSveltosAgentLabels(clusterNamespace, clusterName string,
 	lbls["cluster-namespace"] = clusterNamespace
 	lbls["cluster-name"] = clusterName
 	lbls["cluster-type"] = strings.ToLower(string(clusterType))
+	lbls["feature"] = "sveltos-agent"
 	return lbls
 }
 


### PR DESCRIPTION
Add an extra label identifying those resources are deployed for sveltos-agent feature.

Sveltos has two agents that can be deployed in the management cluster:
1. sveltos-agent
2. drift-detection-manager

By default those are installed in the managed cluster but sveltos has an option to be instructed to deploy those in the management cluster.

When deployed in the management cluster, those resources are in the projectsveltos namespace and a set of resources (service plus deployment) is deployed for each managed cluster.

Sveltosm adds labels to those resources and use those labels to:
1. identify whether resources are already deployed
2. remove those resources when cluster is deleted

Before this PR, labels added on sveltos-agent resources and drift-detection-manager resources were same, so there was no way to differentiate.

This PR adds an extra label to solve this problem.