### PR TITLE
(feat) compatibility checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,4 +15,4 @@ spec:
         - "--report-mode=0"
         - "--shard-key="
         - "--v=5"
-        - "--version=main"
+        - "--version=dev"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/classifier:main
+      - image: docker.io/projectsveltos/classifier:dev
         name: manager

--- a/controllers/classifier_controller.go
+++ b/controllers/classifier_controller.go
@@ -337,7 +337,7 @@ func (r *ClassifierReconciler) SetupWithManager(mgr ctrl.Manager) (controller.Co
 	// Later on, in main, we detect that and if CAPI is present WatchForCAPI will be invoked.
 
 	if r.ClassifierReportMode == CollectFromManagementCluster {
-		go collectClassifierReports(mgr.GetClient(), r.ShardKey, mgr.GetLogger())
+		go collectClassifierReports(mgr.GetClient(), r.ShardKey, getVersion(), mgr.GetLogger())
 	}
 
 	return c, nil

--- a/controllers/classifier_controller_test.go
+++ b/controllers/classifier_controller_test.go
@@ -480,6 +480,7 @@ var _ = Describe("ClassifierReconciler: requeue methods", func() {
 
 	BeforeEach(func() {
 		cluster = prepareCluster()
+		controllers.SetVersion(version)
 
 		classifier = getClassifierInstance(randomString())
 	})

--- a/controllers/classifier_deployer_test.go
+++ b/controllers/classifier_deployer_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Classifier Deployer", func() {
 
 	BeforeEach(func() {
 		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		controllers.SetVersion(version)
 	})
 
 	It("classifierHash returns Classifier hash", func() {
@@ -85,6 +86,7 @@ var _ = Describe("Classifier Deployer", func() {
 		h := sha256.New()
 		var config string
 
+		config += version
 		config += render.AsCode(classifier.Spec)
 		h.Write([]byte(config))
 		hash := h.Sum(nil)
@@ -690,6 +692,22 @@ func prepareCluster() *clusterv1.Cluster {
 	}
 	Expect(testEnv.Client.Create(context.TODO(), secret)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv.Client, secret)).To(Succeed())
+
+	By("Create the ConfigMap with sveltos-agent version")
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: projectsveltosNamespace,
+			Name:      "sveltos-agent-version",
+		},
+		Data: map[string]string{
+			"sveltos-agent-version": version,
+		},
+	}
+	err := testEnv.Client.Create(context.TODO(), cm)
+	if err != nil {
+		Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
+	}
+	Expect(waitForObject(context.TODO(), testEnv.Client, cm)).To(Succeed())
 
 	Expect(addTypeInformationToObject(scheme, cluster)).To(Succeed())
 

--- a/controllers/classifier_report_collection_test.go
+++ b/controllers/classifier_report_collection_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Classifier Deployer", func() {
 		Expect(waitForObject(context.TODO(), testEnv.Client, classifierReport)).To(Succeed())
 
 		Expect(controllers.CollectClassifierReportsFromCluster(context.TODO(), testEnv.Client, getClusterRef(cluster),
-			logger)).To(Succeed())
+			version, logger)).To(Succeed())
 
 		clusterType := libsveltosv1beta1.ClusterTypeCapi
 
@@ -133,7 +133,7 @@ var _ = Describe("Classifier Deployer", func() {
 
 		// Update ClassifierReports and validate again
 		Expect(controllers.CollectClassifierReportsFromCluster(context.TODO(), testEnv.Client, getClusterRef(cluster),
-			logger)).To(Succeed())
+			version, logger)).To(Succeed())
 
 		validateClassifierReports(classifierName, cluster, &clusterType)
 	})

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -70,11 +70,13 @@ const (
 	upstreamClusterNamePrefix = "upstream-cluster"
 	upstreamMachineNamePrefix = "upstream-machine"
 	clusterKind               = "Cluster"
+	projectsveltosNamespace   = "projectsveltos"
 )
 
 const (
 	timeout         = 40 * time.Second
 	pollingInterval = 2 * time.Second
+	version         = "v0.31.0"
 )
 
 func TestControllers(t *testing.T) {
@@ -121,6 +123,14 @@ var _ = BeforeSuite(func() {
 	classifierReportCRD, err := utils.GetUnstructured(crd.GetClassifierReportCRDYAML())
 	Expect(err).To(BeNil())
 	Expect(testEnv.Create(ctx, classifierReportCRD)).To(Succeed())
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: projectsveltosNamespace,
+		},
+	}
+	Expect(testEnv.Create(ctx, ns)).To(Succeed())
+	Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
 
 	if synced := testEnv.GetCache().WaitForCacheSync(ctx); !synced {
 		time.Sleep(time.Second)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f
+	github.com/projectsveltos/libsveltos v0.37.1-0.20240903133242-23de3048ef2a
 	github.com/prometheus/client_golang v1.20.2
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/text v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f h1:eeVqeBF8YJsf42bMhxQlHyQuV5GYBc1UrV9DMiAh588=
-github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f/go.mod h1:YZQWtvZUDfg2VbjrPEGVQZa/yxq0n+KMV58iro7L5yg=
+github.com/projectsveltos/libsveltos v0.37.1-0.20240903133242-23de3048ef2a h1:ydhJD/+j1iT/qwsS/dInlqSJ+Zz9VkW0XUmEP6Rk2js=
+github.com/projectsveltos/libsveltos v0.37.1-0.20240903133242-23de3048ef2a/go.mod h1:YZQWtvZUDfg2VbjrPEGVQZa/yxq0n+KMV58iro7L5yg=
 github.com/prometheus/client_golang v1.20.2 h1:5ctymQzZlyOON1666svgwn3s6IKWgfbjsejTMiXIyjg=
 github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/main.go
+++ b/main.go
@@ -152,6 +152,8 @@ func main() {
 		}
 	}
 
+	controllers.SetVersion(version)
+
 	classifierReconciler := getClassifierReconciler(mgr)
 	classifierReconciler.Deployer = d
 	var classifierController controller.Controller
@@ -171,8 +173,6 @@ func main() {
 	//+kubebuilder:scaffold:builder
 
 	setupChecks(mgr)
-
-	controllers.SetVersion(version)
 
 	go capiWatchers(ctx, mgr,
 		classifierReconciler, classifierController,

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --agent-in-mgmt-cluster
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:main
+        image: docker.io/projectsveltos/classifier:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --shard-key={{.SHARD}}
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:main
+        image: docker.io/projectsveltos/classifier:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -157,10 +157,10 @@ spec:
         - --report-mode=0
         - --shard-key=
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:main
+        image: docker.io/projectsveltos/classifier:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.go
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.go
@@ -42,11 +42,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
+        - --version=dev
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent:main
+        image: docker.io/projectsveltos/sveltos-agent:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
@@ -24,11 +24,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
+        - --version=dev
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent:main
+        image: docker.io/projectsveltos/sveltos-agent:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.go
+++ b/pkg/agent/sveltos-agent.go
@@ -33,6 +33,16 @@ metadata:
   name: sveltos-agent-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'
@@ -183,11 +193,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
+        - --version=dev
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent:main
+        image: docker.io/projectsveltos/sveltos-agent:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.yaml
+++ b/pkg/agent/sveltos-agent.yaml
@@ -15,6 +15,16 @@ metadata:
   name: sveltos-agent-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'
@@ -165,11 +175,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
+        - --version=dev
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent:main
+        image: docker.io/projectsveltos/sveltos-agent:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Before fecthing classifierReports from each managed cluster, verify sveltos-agent is running a compatible version.

Sveltos-agent when started, writes its version on a ConfigMap in the projectsveltos namespace. Before fetching ClassifierReports, classifier verifies such version is compatible.