### PR TITLE
(feat) CAPI clusters

### DIFF
--- a/controllers/classifier_report_collection.go
+++ b/controllers/classifier_report_collection.go
@@ -121,7 +121,9 @@ func removeClusterClassifierReports(ctx context.Context, c client.Client, cluste
 
 // Periodically collects ClassifierReports from each cluster.
 // If sharding is used, it will collect only from clusters matching shard.
-func collectClassifierReports(c client.Client, shardKey, version string, logger logr.Logger) {
+func collectClassifierReports(c client.Client, shardKey, capiOnboardAnnotation, version string,
+	logger logr.Logger) {
+
 	interval := 10 * time.Second
 	if shardKey != "" {
 		// This controller will only fetch ClassifierReport instances
@@ -133,7 +135,7 @@ func collectClassifierReports(c client.Client, shardKey, version string, logger 
 	for {
 		logger.V(logs.LogDebug).Info("collecting ClassifierReports")
 		// Get a selectors that matches everything
-		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", shardKey, logger)
+		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", capiOnboardAnnotation, shardKey, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get clusters: %v", err))
 		}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.48.1
+	github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f
 	github.com/prometheus/client_golang v1.20.5
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/text v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v0.48.1 h1:SWtACXeVNehWNxh/jEeFB/Z1QqMd4HeSh5Z60czwJbQ=
-github.com/projectsveltos/libsveltos v0.48.1/go.mod h1:9z2AUhSE2qzi+m5tqeQUMm+c4whMtbKH6oYOYY+0tbw=
+github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f h1:QyRB2GW8b2D4d9a5fT8spSSW5NzDzOdz/cQsg7toehs=
+github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f/go.mod h1:9z2AUhSE2qzi+m5tqeQUMm+c4whMtbKH6oYOYY+0tbw=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
 github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ var (
 	version                               string
 	healthAddr                            string
 	sveltosAgentConfigMap                 string
+	capiOnboardAnnotation                 string
 )
 
 const (
@@ -194,6 +195,9 @@ func initFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&shardKey, "shard-key", "",
 		"If set, and report-mode is set to collect, this deployment will fetch only from clusters matching this shard")
+
+	fs.StringVar(&capiOnboardAnnotation, "capi-onboard-annotation", "",
+		"If provided, Sveltos will only manage CAPI clusters that have this exact annotation.")
 
 	fs.StringVar(&managementClusterControlPlaneEndpoint, "control-plane-endpoint", "",
 		"The management cluster controlplane endpoint. Format <ip>:<port>.")
@@ -315,16 +319,17 @@ func capiWatchers(ctx context.Context, mgr ctrl.Manager,
 
 func getClassifierReconciler(mgr manager.Manager) *controllers.ClassifierReconciler {
 	return &controllers.ClassifierReconciler{
-		Client:               mgr.GetClient(),
-		Scheme:               mgr.GetScheme(),
-		ConcurrentReconciles: concurrentReconciles,
-		ClusterMap:           make(map[corev1.ObjectReference]*libsveltosset.Set),
-		ClassifierMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
-		ShardKey:             shardKey,
-		AgentInMgmtCluster:   agentInMgmtCluster,
-		ClassifierReportMode: reportMode,
-		ControlPlaneEndpoint: managementClusterControlPlaneEndpoint,
-		Mux:                  sync.Mutex{},
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		ConcurrentReconciles:  concurrentReconciles,
+		ClusterMap:            make(map[corev1.ObjectReference]*libsveltosset.Set),
+		ClassifierMap:         make(map[corev1.ObjectReference]*libsveltosset.Set),
+		ShardKey:              shardKey,
+		CapiOnboardAnnotation: capiOnboardAnnotation,
+		AgentInMgmtCluster:    agentInMgmtCluster,
+		ClassifierReportMode:  reportMode,
+		ControlPlaneEndpoint:  managementClusterControlPlaneEndpoint,
+		Mux:                   sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
classifier can be passed a new arg: `capi-onboard-annotation`. It allows administrators to specify a custom annotation key. When this annotation is set, Sveltos will only manage CAPI clusters that have this specific annotation with any value.

CAPI clusters without this annotation will be ignored by Sveltos.