### PR TITLE
Add registry option

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -17,3 +17,4 @@ spec:
         - --capi-onboard-annotation=
         - "--v=5"
         - "--version=main"
+        - "--registry="

--- a/controllers/management_cluster.go
+++ b/controllers/management_cluster.go
@@ -29,6 +29,7 @@ var (
 	managementClusterConfig *rest.Config
 	managementClusterClient client.Client
 	sveltosAgentConfigMap   string
+	registry                string
 )
 
 func SetManagementClusterAccess(config *rest.Config, c client.Client) {
@@ -38,6 +39,10 @@ func SetManagementClusterAccess(config *rest.Config, c client.Client) {
 
 func SetSveltosAgentConfigMap(name string) {
 	sveltosAgentConfigMap = name
+}
+
+func SetSveltosAgentRegistry(reg string) {
+	registry = reg
 }
 
 func getManagementClusterConfig() *rest.Config {
@@ -50,6 +55,10 @@ func getManagementClusterClient() client.Client {
 
 func getSveltosAgentConfigMap() string {
 	return sveltosAgentConfigMap
+}
+
+func GetSveltosAgentRegistry() string {
+	return registry
 }
 
 func collectSveltosAgentConfigMap(ctx context.Context, name string) (*corev1.ConfigMap, error) {

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ var (
 	healthAddr                            string
 	sveltosAgentConfigMap                 string
 	capiOnboardAnnotation                 string
+	registry                              string
 )
 
 const (
@@ -134,6 +135,7 @@ func main() {
 
 	controllers.SetManagementClusterAccess(mgr.GetConfig(), mgr.GetClient())
 	controllers.SetSveltosAgentConfigMap(sveltosAgentConfigMap)
+	controllers.SetSveltosAgentRegistry(registry)
 
 	// Setup the context that's going to be used in controllers and for the manager.
 	ctx := ctrl.SetupSignalHandler()
@@ -224,6 +226,9 @@ func initFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
+
+	fs.StringVar(&registry, "registry", "",
+		"Container registry for sveltos-agent images. Defaults to docker.io/ if empty.")
 
 	const defautlRestConfigQPS = 20
 	fs.Float32Var(&restConfigQPS, "kube-api-qps", defautlRestConfigQPS,

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -25,6 +25,7 @@ spec:
         - --capi-onboard-annotation=
         - --v=5
         - --version=main
+        - --registry=
         command:
         - /manager
         image: docker.io/projectsveltos/classifier:main

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -25,6 +25,7 @@ spec:
         - --capi-onboard-annotation=
         - --v=5
         - --version=main
+        - --registry=
         command:
         - /manager
         image: docker.io/projectsveltos/classifier:main

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -159,6 +159,7 @@ spec:
         - --capi-onboard-annotation=
         - --v=5
         - --version=main
+        - --registry=
         command:
         - /manager
         image: docker.io/projectsveltos/classifier:main


### PR DESCRIPTION
If set this will replace `docker.io` with the value passed. For instance to use mirror.gcr.io

```
- --registry=mirror.gcr.io/projectsveltos
```

Part of [102](https://github.com/projectsveltos/helm-charts/issues/102)