### PR TITLE
(feat) sveltos-agent deployment

### DIFF
--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -77,7 +77,7 @@ func newClassifierHistogram(clusterNamespace, clusterName string, clusterType li
 }
 
 func logCollectorError(err error, logger logr.Logger) {
-	logger.V(logs.LogInfo).Info(fmt.Sprint("failed to register collector: %w", err))
+	logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to register collector: %v", err))
 }
 
 func programDuration(elapsed time.Duration, clusterNamespace, clusterName, featureID string,


### PR DESCRIPTION
Set Spec.Template.Labels so to easily identify which sveltos-agent pod represents which clusters

```
sveltos-agent-iarfy6s64yx5v8joyklp-7d7689449f-57mlg   0/1     Running   0          15s   cluster-name=clusterapi-workload,cluster-namespace=default,cluster-type=capi,control-plane=sveltos-agent-iarfy6s64yx5v8joyklp,feature=sveltos-agent,pod-template-hash=7d7689449f
```