### PR TITLE
(bug) CRDs with agent less mode

### DIFF
--- a/controllers/classifier_controller.go
+++ b/controllers/classifier_controller.go
@@ -199,11 +199,15 @@ func (r *ClassifierReconciler) reconcileDelete(
 		return reconcile.Result{}, err
 	}
 
-	f := getHandlersForFeature(libsveltosv1beta1.FeatureClassifier)
-	err = r.undeployClassifier(ctx, classifierScope, f, logger)
-	if err != nil {
-		logger.V(logs.LogInfo).Error(err, "failed to undeploy")
-		return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
+	if !r.AgentInMgmtCluster {
+		// In agentless mode, Classifier instances are not copied to managed clusters.
+		// So there is nothing to remove from managed cluster.
+		f := getHandlersForFeature(libsveltosv1beta1.FeatureClassifier)
+		err = r.undeployClassifier(ctx, classifierScope, f, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to undeploy")
+			return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
+		}
 	}
 
 	err = removeClassifierReports(ctx, r.Client, classifierScope.Classifier, logger)

--- a/controllers/classifier_deployer.go
+++ b/controllers/classifier_deployer.go
@@ -373,6 +373,12 @@ func updateSecretWithAccessManagementKubeconfig(ctx context.Context, c client.Cl
 func deployCRDs(ctx context.Context, c client.Client, clusterNamespace, clusterName string,
 	clusterType libsveltosv1beta1.ClusterType, logger logr.Logger) error {
 
+	if getAgentInMgmtCluster() {
+		// CRDs must be deployed alongside the agent. Since the management cluster already contains these CRDs,
+		// this operation is a no-op if the agent is deployed there.
+		return nil
+	}
+
 	remoteRestConfig, err := clusterproxy.GetKubernetesRestConfig(ctx, c, clusterNamespace, clusterName,
 		"", "", clusterType, logger)
 	if err != nil {


### PR DESCRIPTION
When Sveltos is deployed in agentless mode (sveltos agent and drift detection manager running in the management cluster), all Sveltos resources used for events, health checks, configuration drift detection and more, are created in the management cluster itself. So in this mode there is no need to deploy Sveltos CRDs in each managed cluster.