### PR TITLE
(chore) classifierReports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.0.0-beta.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,6 +16,6 @@ spec:
         - "--shard-key="
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.0.0-beta.0"
+        - "--version=main"
         - "--registry="
         - "--agent-in-mgmt-cluster=false"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/classifier:v1.0.0-beta.0
+      - image: docker.io/projectsveltos/classifier:main
         name: manager

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -24,12 +24,12 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0-beta.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.0.0-beta.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,12 +24,12 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0-beta.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.0.0-beta.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -162,12 +162,12 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0-beta.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.0.0-beta.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.go
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.go
@@ -42,12 +42,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0-beta.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent@sha256:523e3e3d94592e0d85ef0e96ed78d767d5006f8efb0abf3edd15e7e34758c5dc
+        image: docker.io/projectsveltos/sveltos-agent@sha256:fbd928be1cc5042bd509665defdd16da9d3e6f85b44130b96db754bf7e719779
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
@@ -24,12 +24,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0-beta.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent@sha256:523e3e3d94592e0d85ef0e96ed78d767d5006f8efb0abf3edd15e7e34758c5dc
+        image: docker.io/projectsveltos/sveltos-agent@sha256:fbd928be1cc5042bd509665defdd16da9d3e6f85b44130b96db754bf7e719779
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.go
+++ b/pkg/agent/sveltos-agent.go
@@ -193,12 +193,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0-beta.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent@sha256:523e3e3d94592e0d85ef0e96ed78d767d5006f8efb0abf3edd15e7e34758c5dc
+        image: docker.io/projectsveltos/sveltos-agent@sha256:fbd928be1cc5042bd509665defdd16da9d3e6f85b44130b96db754bf7e719779
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.yaml
+++ b/pkg/agent/sveltos-agent.yaml
@@ -175,12 +175,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0-beta.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent@sha256:523e3e3d94592e0d85ef0e96ed78d767d5006f8efb0abf3edd15e7e34758c5dc
+        image: docker.io/projectsveltos/sveltos-agent@sha256:fbd928be1cc5042bd509665defdd16da9d3e6f85b44130b96db754bf7e719779
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
When agents are in the management cluster and in pull mode, when collecting ClassifierReports for a given cluster, filter by cluster namespace, name and type.