### PR TITLE
(bug) cleanup of stale resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.0.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,6 +16,6 @@ spec:
         - "--shard-key="
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.0.0"
+        - "--version=main"
         - "--registry="
         - "--agent-in-mgmt-cluster=false"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/classifier:v1.0.0
+      - image: docker.io/projectsveltos/classifier:main
         name: manager

--- a/controllers/classifier_controller.go
+++ b/controllers/classifier_controller.go
@@ -300,7 +300,9 @@ func (r *ClassifierReconciler) reconcileNormal(
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ClassifierReconciler) SetupWithManager(mgr ctrl.Manager) (controller.Controller, error) {
+func (r *ClassifierReconciler) SetupWithManager(ctx context.Context,
+	mgr ctrl.Manager, logger logr.Logger) (controller.Controller, error) {
+
 	// When Classifier changes, according to ClassifierPredicates,
 	// all Classifier with at least one conflict needs to be reconciled
 
@@ -349,6 +351,10 @@ func (r *ClassifierReconciler) SetupWithManager(mgr ctrl.Manager) (controller.Co
 
 	if r.ClassifierReportMode == CollectFromManagementCluster {
 		go collectClassifierReports(mgr.GetClient(), r.ShardKey, r.CapiOnboardAnnotation, getVersion(), mgr.GetLogger())
+	}
+
+	if getAgentInMgmtCluster() {
+		go removeStaleClassifierResources(ctx, logger)
 	}
 
 	return c, nil

--- a/controllers/classifier_deployer.go
+++ b/controllers/classifier_deployer.go
@@ -66,7 +66,11 @@ type feature struct {
 }
 
 const (
-	sveltosAgent = "sveltos-agent"
+	sveltosAgent                      = "sveltos-agent"
+	sveltosAgentFeatureLabelKey       = "feature"
+	sveltosAgentClusterNamespaceLabel = "cluster-namespace"
+	sveltosAgentClusterNameLabel      = "cluster-name"
+	sveltosAgentClusterTypeLabel      = "cluster-type"
 )
 
 func getSveltosAgentNamespace() string {
@@ -1617,10 +1621,10 @@ func getSveltosAgentLabels(clusterNamespace, clusterName string,
 	// Following labels are added on the objects representing the
 	// sveltos-agent for this cluster.
 	lbls := make(map[string]string)
-	lbls["cluster-namespace"] = clusterNamespace
-	lbls["cluster-name"] = clusterName
-	lbls["cluster-type"] = strings.ToLower(string(clusterType))
-	lbls["feature"] = sveltosAgent
+	lbls[sveltosAgentClusterNamespaceLabel] = clusterNamespace
+	lbls[sveltosAgentClusterNameLabel] = clusterName
+	lbls[sveltosAgentClusterTypeLabel] = strings.ToLower(string(clusterType))
+	lbls[sveltosAgentFeatureLabelKey] = sveltosAgent
 	return lbls
 }
 

--- a/main.go
+++ b/main.go
@@ -163,7 +163,7 @@ func main() {
 	classifierReconciler := getClassifierReconciler(mgr)
 	classifierReconciler.Deployer = d
 	var classifierController controller.Controller
-	classifierController, err = classifierReconciler.SetupWithManager(mgr)
+	classifierController, err = classifierReconciler.SetupWithManager(ctx, mgr, ctrl.Log.WithName("classifierreconcilier"))
 	if err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Classifier")
 		os.Exit(1)

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -24,12 +24,12 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.0.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,12 +24,12 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.0.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -162,12 +162,12 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.0.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.go
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.go
@@ -42,12 +42,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent@sha256:7bd5b868568692c653733ef19dd34237bd361e3bed8749b2bc4d6000c077728e
+        image: docker.io/projectsveltos/sveltos-agent@sha256:7c130003bfbdf29d673f733b28c11ed5771fffe1de9bb455e0749e63f113e8f0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
@@ -24,12 +24,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent@sha256:7bd5b868568692c653733ef19dd34237bd361e3bed8749b2bc4d6000c077728e
+        image: docker.io/projectsveltos/sveltos-agent@sha256:7c130003bfbdf29d673f733b28c11ed5771fffe1de9bb455e0749e63f113e8f0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.go
+++ b/pkg/agent/sveltos-agent.go
@@ -193,12 +193,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent@sha256:7bd5b868568692c653733ef19dd34237bd361e3bed8749b2bc4d6000c077728e
+        image: docker.io/projectsveltos/sveltos-agent@sha256:7c130003bfbdf29d673f733b28c11ed5771fffe1de9bb455e0749e63f113e8f0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.yaml
+++ b/pkg/agent/sveltos-agent.yaml
@@ -175,12 +175,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.0.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent@sha256:7bd5b868568692c653733ef19dd34237bd361e3bed8749b2bc4d6000c077728e
+        image: docker.io/projectsveltos/sveltos-agent@sha256:7c130003bfbdf29d673f733b28c11ed5771fffe1de9bb455e0749e63f113e8f0
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
When agents operate from the management cluster, a dedicated sveltos-agent deployment is created for each managed cluster.

A SveltosCluster and a Cluster controller are designed to automatically remove these sveltos-agent deployments when a cluster is deleted. However, because there are no Sveltos finalizers on the SveltosCluster or the ClusterAPI cluster instances, it is possible for the classifier to miss a deletion event— for example, if it's temporarily offline.

This update introduces a new logic to periodically scan for and remove any sveltos-agent deployments that are "stale," meaning they correspond to clusters that no longer exist. This ensures that agents are correctly cleaned up, even if a deletion notification is missed.

Fixes https://github.com/projectsveltos/sveltos/issues/603