### PR TITLE
(bug) Ignore not existing cluster errors

### DIFF
--- a/controllers/classifier_controller.go
+++ b/controllers/classifier_controller.go
@@ -569,6 +569,10 @@ func (r *ClassifierReconciler) updateLabelsOnMatchingClusters(ctx context.Contex
 		l.V(logs.LogDebug).Info("update labels on cluster")
 		err = r.updateLabelsOnCluster(ctx, classifierScope, cluster, clusterproxy.GetClusterType(ref), l)
 		if err != nil {
+			// If cluster was removed before classifier had a chance to react to it, ignore the error
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
 			l.V(logs.LogDebug).Error(err, "failed to update labels on cluster")
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -106,9 +106,9 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
 
-	reportMode = controllers.ReportMode(tmpReportMode)
-
 	ctrl.SetLogger(klog.Background())
+
+	reportMode = controllers.ReportMode(tmpReportMode)
 
 	ctrlOptions := ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
When reconciling a Classifier instance, if a cluster is not found ignore the error