### PR TITLE
Clean up managed labels when clusters no longer match

### DIFF
--- a/controllers/classifier_predicates.go
+++ b/controllers/classifier_predicates.go
@@ -252,7 +252,7 @@ func ClassifierReportPredicate(logger logr.Logger) predicate.Funcs {
 			// return true if ClassifierReport.Spec.Match has changed
 			if oldReport.Spec.Match != newReport.Spec.Match {
 				log.V(logs.LogVerbose).Info(
-					"Cluster was unpaused. Will attempt to reconcile associated Classifiers.")
+					"ClassifierReport Spec.Match changed. Will attempt to reconcile associated Classifiers.")
 				return true
 			}
 

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -54,10 +54,11 @@ var (
 	RequeueClassifierForClassifierReport   = (*ClassifierReconciler).requeueClassifierForClassifierReport
 	UpdateMatchingClustersAndRegistrations = (*ClassifierReconciler).updateMatchingClustersAndRegistrations
 	UpdateLabelsOnMatchingClusters         = (*ClassifierReconciler).updateLabelsOnMatchingClusters
-	HandleLabelRegistrations               = (*ClassifierReconciler).handleLabelRegistrations
+	RegisterMatchingClusters               = (*ClassifierReconciler).registerMatchingClusters
 	UndeployClassifier                     = (*ClassifierReconciler).undeployClassifier
 	RemoveAllRegistrations                 = (*ClassifierReconciler).removeAllRegistrations
 	ClassifyLabels                         = (*ClassifierReconciler).classifyLabels
+	CleanUpNonMatchingClusters             = (*ClassifierReconciler).cleanUpNonMatchingClusters
 )
 
 var (

--- a/test/fv/conflict_test.go
+++ b/test/fv/conflict_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Classifier: update cluster labels", func() {
 			return err != nil && apierrors.IsNotFound(err)
 		}, timeout, pollingInterval).Should(BeTrue())
 
-		verifyClusterLabels(classifier2)
+		verifyClusterLabelsAreGone(classifier2)
 
 		removeLabels(classifier1)
 		removeLabels(classifier2)

--- a/test/fv/report_match_change_test.go
+++ b/test/fv/report_match_change_test.go
@@ -129,8 +129,8 @@ var _ = Describe("Classifier: update cluster labels", func() {
 			return err != nil && apierrors.IsNotFound(err)
 		}, timeout, pollingInterval).Should(BeTrue())
 
-		Byf("Verifying Cluster labels are not updated because of Classifier being deleted")
-		verifyClusterLabels(classifier)
+		Byf("Verifying Cluster labels are removed because of Classifier being deleted")
+		verifyClusterLabelsAreGone(classifier)
 
 		removeLabels(classifier)
 	})


### PR DESCRIPTION
Implements label cleanup logic for the Classifier controller. When a cluster is no longer a match for a Classifier instance, or when the Classifier itself is deleted, the controller now removes all labels it previously managed on those clusters.

This ensures no stale metadata remains on the underlying cluster resources.

The removal logic is guarded by the KeyManager to prevent the accidental deletion of labels managed by other Classifier instances.

Fixes #436 