### PR TITLE
Advance sveltos-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.5.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,6 +16,6 @@ spec:
         - "--shard-key="
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.5.0"
+        - "--version=main"
         - "--registry="
         - "--agent-in-mgmt-cluster=false"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/classifier:v1.5.0
+      - image: docker.io/projectsveltos/classifier:main
         name: manager

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -24,12 +24,12 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.5.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.5.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,12 +24,12 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.5.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.5.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -168,12 +168,12 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.5.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.5.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.go
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.go
@@ -42,7 +42,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.5.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -57,7 +57,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:5789484c29dd153653fbd7d822e458348502d3a6d710d5661e26b17f7050d698
+        image: docker.io/projectsveltos/sveltos-agent@sha256:f888233af1cf1737687668c03d1b683d47bbc7b728180ebf22b8485b6683b27e
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
@@ -24,7 +24,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.5.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:5789484c29dd153653fbd7d822e458348502d3a6d710d5661e26b17f7050d698
+        image: docker.io/projectsveltos/sveltos-agent@sha256:f888233af1cf1737687668c03d1b683d47bbc7b728180ebf22b8485b6683b27e
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.go
+++ b/pkg/agent/sveltos-agent.go
@@ -201,7 +201,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.5.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -216,7 +216,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:5789484c29dd153653fbd7d822e458348502d3a6d710d5661e26b17f7050d698
+        image: docker.io/projectsveltos/sveltos-agent@sha256:f888233af1cf1737687668c03d1b683d47bbc7b728180ebf22b8485b6683b27e
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.yaml
+++ b/pkg/agent/sveltos-agent.yaml
@@ -183,7 +183,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.5.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -198,7 +198,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:5789484c29dd153653fbd7d822e458348502d3a6d710d5661e26b17f7050d698
+        image: docker.io/projectsveltos/sveltos-agent@sha256:f888233af1cf1737687668c03d1b683d47bbc7b728180ebf22b8485b6683b27e
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-applier.go
+++ b/pkg/agent/sveltos-applier.go
@@ -117,7 +117,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:2fa56ecc207989f12d2801ac5b1fb04aba9855979b4315bb86e02a8d53ba2625
+        image: docker.io/projectsveltos/sveltos-applier:v1.5.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-applier.yaml
+++ b/pkg/agent/sveltos-applier.yaml
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:2fa56ecc207989f12d2801ac5b1fb04aba9855979b4315bb86e02a8d53ba2625
+        image: docker.io/projectsveltos/sveltos-applier:v1.5.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -83,7 +83,7 @@ spec:
         - --cluster-type=sveltos
         - --secret-with-kubeconfig=clusterapi-workload-sveltos-kubeconfig
         - --v=5
-        - --version=main
+        - --version=v1.5.0
         command:
         - /manager
         env:
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:2fa56ecc207989f12d2801ac5b1fb04aba9855979b4315bb86e02a8d53ba2625
+        image: docker.io/projectsveltos/sveltos-applier:v1.5.0
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
This picks this sveltos-agent optmization:

Both sveltos-agent and the agents running in the control cluster (classifier, event-manager and healthcheck-manager) update status for ClassifierReport, EventReport and HealthCheckReport.

Sveltos-agent updates it to indicate there is a new report to be processed. The agents in the control cluster to indicate the latest report has been processed.

This PR optimizes the status update logic for the EventReport, HealthCheckReport, and ClassifierReport controllers.

Previously, concurrent updates by multiple managers or controllers some time resulted in 409 Conflict errors. This forced the classifier/eventSource/healthCheck to be re-evaluated again.

The code now attempts an immediate status update with the existing resourceVersion. It only performs a Get() request if a conflict is actually detected, saving one API call in ~90% of cases.