### PR TITLE
(chore) update sveltos-agent image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.6.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,6 +16,6 @@ spec:
         - "--shard-key="
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.6.0"
+        - "--version=main"
         - "--registry="
         - "--agent-in-mgmt-cluster=false"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/classifier:v1.6.0
+      - image: docker.io/projectsveltos/classifier:main
         name: manager

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -24,12 +24,12 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.6.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.6.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,12 +24,12 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.6.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.6.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -168,12 +168,12 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.6.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.6.0
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.go
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.go
@@ -42,7 +42,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.6.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -57,7 +57,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:16b0272d99f04af0818906fb5279473991e8eb8a3bc661e8ac378ef4ae68fd2f
+        image: docker.io/projectsveltos/sveltos-agent@sha256:fb65087f04fab47e64f13bdce571b29ea382803e8e348aeef2bd1a4be599a821
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
@@ -24,7 +24,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.6.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:16b0272d99f04af0818906fb5279473991e8eb8a3bc661e8ac378ef4ae68fd2f
+        image: docker.io/projectsveltos/sveltos-agent@sha256:fb65087f04fab47e64f13bdce571b29ea382803e8e348aeef2bd1a4be599a821
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.go
+++ b/pkg/agent/sveltos-agent.go
@@ -201,7 +201,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.6.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -216,7 +216,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:16b0272d99f04af0818906fb5279473991e8eb8a3bc661e8ac378ef4ae68fd2f
+        image: docker.io/projectsveltos/sveltos-agent@sha256:fb65087f04fab47e64f13bdce571b29ea382803e8e348aeef2bd1a4be599a821
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.yaml
+++ b/pkg/agent/sveltos-agent.yaml
@@ -183,7 +183,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.6.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -198,7 +198,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:16b0272d99f04af0818906fb5279473991e8eb8a3bc661e8ac378ef4ae68fd2f
+        image: docker.io/projectsveltos/sveltos-agent@sha256:fb65087f04fab47e64f13bdce571b29ea382803e8e348aeef2bd1a4be599a821
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
This picks an optmization in how EventSource and HealthCheck instances are re-queued for re-evaluation