### PR TITLE
(feat) allow configurable namespace for Sveltos

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,3 +94,16 @@ jobs:
       run: make create-cluster-pullmode fv-pullmode
       env:
         FV: true
+  FV-NAMESPACE:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: 1.26.3
+    - name: fv
+      run: make create-cluster-infra fv-namespace
+      env:
+        FV: true

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.10.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen
@@ -186,6 +186,9 @@ NUM_NODES ?= 5
 .PHONY: kind-test
 kind-test: test create-cluster fv ## Build docker image; start kind cluster; load docker image; install all cluster api components and run fv
 
+.PHONY: kind-test-namespace
+kind-test-namespace: test create-cluster-infra fv-namespace ## Build docker image; start kind cluster; deploy Sveltos in a random namespace and run fv
+
 .PHONY: fv
 fv: $(GINKGO) ## Run Sveltos Controller tests using existing cluster
 	cd test/fv; $(GINKGO) -nodes $(NUM_NODES) --label-filter='FV' --v --trace --randomize-all
@@ -212,13 +215,44 @@ fv-agentless: $(KUBECTL) $(GINKGO) ## Run Sveltos Controller tests using existin
 fv-pullmode: $(GINKGO) ## Run Sveltos Controller tests using existing cluster
 	cd test/fv; $(GINKGO) -nodes $(NUM_NODES) --label-filter='PULLMODE' --v --trace --randomize-all
 
+.PHONY: deploy-crds
+deploy-crds: $(KUBECTL) ## Install all required Sveltos CRDs
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_debuggingconfigurations.lib.projectsveltos.io.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_classifiers.lib.projectsveltos.io.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_classifierreports.lib.projectsveltos.io.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_accessrequests.lib.projectsveltos.io.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_rolerequests.lib.projectsveltos.io.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationbundles.lib.projectsveltos.io.yaml
+
+.PHONY: fv-namespace
+fv-namespace: $(GINKGO) $(KUBECTL) $(KUSTOMIZE) $(ENVSUBST) ## Run FV tests with Sveltos deployed in a random namespace
+	$(MAKE) load-image
+	$(MAKE) deploy-crds
+
+	@echo "Deploying access manager"
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/access-manager/$(TAG)/manifest/manifest.yaml
+	@echo "wait for cluster to be provisioned"
+	$(KUBECTL) wait cluster $(WORKLOAD_CLUSTER_NAME) -n default --for=jsonpath='{.status.phase}'=Provisioned --timeout=$(TIMEOUT)
+
+	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	SVELTOS_NS="sveltos-$$(openssl rand -hex 4)"; \
+	echo "Deploying Sveltos classifier in namespace: $$SVELTOS_NS"; \
+	$(KUSTOMIZE) build config/default | $(ENVSUBST) | \
+		sed -E 's/^([[:space:]]+)(name|namespace): projectsveltos$$/\1\2: '"$$SVELTOS_NS"'/' | \
+		$(KUBECTL) apply -f-; \
+	echo "Waiting for classifier-manager to be available in namespace $$SVELTOS_NS..."; \
+	$(KUBECTL) wait --for=condition=Available deployment/classifier-manager -n "$$SVELTOS_NS" --timeout=$(TIMEOUT); \
+	cd test/fv && SVELTOS_NAMESPACE="$$SVELTOS_NS" $(GINKGO) -nodes $(NUM_NODES) --label-filter='FV' --v --trace --randomize-all
+
 
 .PHONY: test
 test: manifests generate fmt vet $(SETUP_ENVTEST) ## Run uts.
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test $(shell go list ./... |grep -v test/fv |grep -v test/helpers) $(TEST_ARGS) -coverprofile cover.out
 
-.PHONY: create-cluster
-create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kind cluster designed for development
+.PHONY: create-cluster-infra
+create-cluster-infra: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create kind cluster and workload cluster without deploying Sveltos
 	$(MAKE) create-control-cluster
 
 	@echo "sleep allowing webhook to be ready"
@@ -227,16 +261,11 @@ create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kin
 	@echo "Create a workload cluster"
 	$(KUBECTL) apply -f $(KIND_CLUSTER_YAML)
 
-	@echo "Start projectsveltos classifier"
-	$(MAKE) deploy-projectsveltos
-
-	@echo "Deploying access manager"
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/access-manager/$(TAG)/manifest/manifest.yaml
-	@echo "wait for cluster to be provisioned"
-	$(KUBECTL) wait cluster $(WORKLOAD_CLUSTER_NAME) -n default --for=jsonpath='{.status.phase}'=Provisioned --timeout=$(TIMEOUT)
-
 	@echo "sleep allowing control plane to be ready"
 	sleep 60
+
+	@echo "wait for cluster to be provisioned"
+	$(KUBECTL) wait cluster $(WORKLOAD_CLUSTER_NAME) -n default --for=jsonpath='{.status.phase}'=Provisioned --timeout=$(TIMEOUT)
 
 	@echo "get kubeconfig to access workload cluster"
 	$(KIND) get kubeconfig --name $(WORKLOAD_CLUSTER_NAME) > test/fv/workload_kubeconfig
@@ -246,6 +275,11 @@ create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kin
 
 	@echo wait for calico pod
 	$(KUBECTL) --kubeconfig=./test/fv/workload_kubeconfig wait --for=condition=Available deployment/calico-kube-controllers -n kube-system --timeout=$(TIMEOUT)
+
+.PHONY: create-cluster
+create-cluster: create-cluster-infra ## Create a new kind cluster designed for development
+	@echo "Start projectsveltos classifier"
+	$(MAKE) deploy-projectsveltos
 
 create-cluster-pullmode: $(KIND) $(KUBECTL) $(ENVSUBST) $(KUSTOMIZE)
 	docker network rm $(SVELTOS_NETWORK_NAME) 2>/dev/null || true
@@ -406,14 +440,10 @@ deploy-projectsveltos: $(KUSTOMIZE)
 	$(MAKE) load-image
 
 	@echo 'Install libsveltos CRDs'
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_debuggingconfigurations.lib.projectsveltos.io.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_classifiers.lib.projectsveltos.io.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_classifierreports.lib.projectsveltos.io.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_accessrequests.lib.projectsveltos.io.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_rolerequests.lib.projectsveltos.io.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationgroups.lib.projectsveltos.io.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_configurationbundles.lib.projectsveltos.io.yaml
+	$(MAKE) deploy-crds
+
+	@echo "Deploying access manager"
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/access-manager/$(TAG)/manifest/manifest.yaml
 
 	# Install projectsveltos classifier components
 	@echo 'Install projectsveltos classifier components'

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,6 +16,19 @@ spec:
         - "--shard-key="
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.10.0"
+        - "--version=main"
         - "--registry="
         - "--agent-in-mgmt-cluster=false"
+        env:
+        - name: TOTAL_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/classifier:v1.10.0
+      - image: docker.io/projectsveltos/classifier:main
         name: manager

--- a/controllers/classifier_controller.go
+++ b/controllers/classifier_controller.go
@@ -77,8 +77,6 @@ const (
 
 	controlplaneendpoint = "controlplaneendpoint-key"
 	configurationHash    = "configurationHash"
-
-	projectsveltos = "projectsveltos"
 )
 
 // ClassifierReconciler reconciles a Classifier object

--- a/controllers/classifier_deployer.go
+++ b/controllers/classifier_deployer.go
@@ -108,8 +108,8 @@ const (
 	sveltosApplierOverrideAnnotation = "sveltosapplier.projectsveltos.io/config-override-ref"
 )
 
-func getSveltosAgentNamespace() string {
-	return projectsveltos
+func getSveltosAgentNamespace(sveltosNamespace string) string {
+	return sveltosNamespace
 }
 
 func (r *ClassifierReconciler) deployClassifier(ctx context.Context, classifierScope *scope.ClassifierScope,
@@ -374,10 +374,10 @@ func getKubeconfigFromAccessRequest(ctx context.Context, c client.Client, cluste
 
 func createSecretNamespace(ctx context.Context, c client.Client) error {
 	ns := &corev1.Namespace{}
-	err := c.Get(ctx, types.NamespacedName{Name: libsveltosv1beta1.ClassifierSecretNamespace}, ns)
+	err := c.Get(ctx, types.NamespacedName{Name: getSveltosNamespace()}, ns)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			ns.Name = libsveltosv1beta1.ClassifierSecretNamespace
+			ns.Name = getSveltosNamespace()
 			return c.Create(ctx, ns)
 		}
 		return err
@@ -406,14 +406,14 @@ func updateSecretWithAccessManagementKubeconfig(ctx context.Context, c client.Cl
 
 	secret := &corev1.Secret{}
 	key := client.ObjectKey{
-		Namespace: libsveltosv1beta1.ClassifierSecretNamespace,
+		Namespace: getSveltosNamespace(),
 		Name:      libsveltosv1beta1.ClassifierSecretName,
 	}
 
 	dataKey := "kubeconfig"
 	err = remoteClient.Get(ctx, key, secret)
 	if err != nil {
-		secret.Namespace = libsveltosv1beta1.ClassifierSecretNamespace
+		secret.Namespace = getSveltosNamespace()
 		secret.Name = libsveltosv1beta1.ClassifierSecretName
 		secret.Data = map[string][]byte{
 			dataKey: kubeconfig,
@@ -1553,7 +1553,7 @@ func createSveltosAgentNamespaceInManagedCluster(ctx context.Context, c client.C
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: getSveltosAgentNamespace(),
+			Name: getSveltosAgentNamespace(getSveltosNamespace()),
 		},
 	}
 
@@ -1671,6 +1671,40 @@ func deploySveltosAgentInManagementCluster(ctx context.Context, restConfig *rest
 		restConfig, agentYAML, lbls, patches, false, logger)
 }
 
+// updateResourceNamespace sets the namespace on a resource that requires it.
+// For namespaced resources the object metadata namespace is updated.
+// For ClusterRoleBinding the subjects are also patched: the resource is cluster-scoped so
+// GetNamespace() returns "" and the plain SetNamespace call would not reach it, but each
+// ServiceAccount subject still carries an explicit namespace that must match the actual
+// location of the ServiceAccount.
+func updateResourceNamespace(policy *unstructured.Unstructured, namespace string) error {
+	if policy.GetNamespace() != "" {
+		policy.SetNamespace(namespace)
+	}
+
+	if policy.GetKind() != "ClusterRoleBinding" {
+		return nil
+	}
+
+	subjects, found, err := unstructured.NestedSlice(policy.Object, "subjects")
+	if err != nil || !found {
+		return err
+	}
+
+	for i := range subjects {
+		subject, ok := subjects[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if subject["kind"] == "ServiceAccount" {
+			subject["namespace"] = namespace
+			subjects[i] = subject
+		}
+	}
+
+	return unstructured.SetNestedSlice(policy.Object, subjects, "subjects")
+}
+
 func deploySveltosAgentResources(ctx context.Context, clusterNamespace, clusterName, classifierName string,
 	restConfig *rest.Config, agentYAML string, lbls map[string]string, patches []libsveltosv1beta1.Patch,
 	isPullMode bool, logger logr.Logger) error {
@@ -1708,6 +1742,11 @@ func deploySveltosAgentResources(ctx context.Context, clusterNamespace, clusterN
 					return err
 				}
 			}
+		}
+
+		if err := updateResourceNamespace(policy, getSveltosNamespace()); err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to update resource namespace")
+			return err
 		}
 
 		var referencedUnstructured []*unstructured.Unstructured
@@ -1762,6 +1801,11 @@ func deploySveltosApplierResources(ctx context.Context, clusterNamespace, cluste
 		policy, err := k8s_utils.GetUnstructured([]byte(elements[i]))
 		if err != nil {
 			logger.V(logs.LogInfo).Error(err, "failed to parse sveltos applier yaml")
+			return err
+		}
+
+		if err := updateResourceNamespace(policy, getSveltosNamespace()); err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to update resource namespace")
 			return err
 		}
 
@@ -1851,7 +1895,8 @@ func getSveltosAgentDeploymentName(ctx context.Context, restConfig *rest.Config,
 	}
 
 	// using client and a List would require permission at cluster level. So using clientset instead
-	deployments, err := clientset.AppsV1().Deployments(getSveltosAgentNamespace()).List(ctx, listOptions)
+	deployments, err := clientset.AppsV1().Deployments(getSveltosAgentNamespace(getSveltosNamespace())).
+		List(ctx, listOptions)
 	if err != nil {
 		return "", err
 	}
@@ -1928,6 +1973,10 @@ func removeSveltosAgentFromManagementCluster(ctx context.Context,
 		if err != nil {
 			logger.V(logs.LogInfo).Error(err, "failed to parse sveltos-agent yaml")
 			return err
+		}
+
+		if policy.GetNamespace() != "" {
+			policy.SetNamespace(getSveltosNamespace())
 		}
 
 		dr, err := k8s_utils.GetDynamicResourceInterface(restConfig, policy.GroupVersionKind(), policy.GetNamespace())
@@ -2028,7 +2077,7 @@ func getSveltosAgentPatchesOld(ctx context.Context, c client.Client,
 	configMap := &corev1.ConfigMap{}
 	if configMapName != "" {
 		err := c.Get(ctx,
-			types.NamespacedName{Namespace: projectsveltos, Name: configMapName},
+			types.NamespacedName{Namespace: getSveltosNamespace(), Name: configMapName},
 			configMap)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get ConfigMap %s: %v",
@@ -2060,7 +2109,7 @@ func getSveltosApplierPatchesOld(ctx context.Context, c client.Client,
 	configMap := &corev1.ConfigMap{}
 	if configMapName != "" {
 		err := c.Get(ctx,
-			types.NamespacedName{Namespace: projectsveltos, Name: configMapName},
+			types.NamespacedName{Namespace: getSveltosNamespace(), Name: configMapName},
 			configMap)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get ConfigMap %s: %v",
@@ -2098,7 +2147,7 @@ func getSveltosAgentPatches(ctx context.Context, c client.Client,
 	}
 
 	configMapName := getSveltosAgentConfigMap()
-	patches, err = getSveltosAgentPatchesNew(ctx, c, projectsveltos, configMapName, logger)
+	patches, err = getSveltosAgentPatchesNew(ctx, c, getSveltosNamespace(), configMapName, logger)
 	if err == nil {
 		return patches, nil
 	}
@@ -2120,7 +2169,7 @@ func getSveltosApplierPatches(ctx context.Context, c client.Client,
 	}
 
 	configMapName := getSveltosApplierConfigMap()
-	patches, err = getSveltosApplierPatchesNew(ctx, c, projectsveltos, configMapName, logger)
+	patches, err = getSveltosApplierPatchesNew(ctx, c, getSveltosNamespace(), configMapName, logger)
 	if err == nil {
 		return patches, nil
 	}

--- a/controllers/classifier_deployer_test.go
+++ b/controllers/classifier_deployer_test.go
@@ -506,7 +506,7 @@ var _ = Describe("Classifier Deployer", func() {
 		Eventually(func() error {
 			currentSveltosAgent := &appsv1.Deployment{}
 			return testEnv.Get(context.TODO(),
-				types.NamespacedName{Namespace: "projectsveltos", Name: "sveltos-agent-manager"},
+				types.NamespacedName{Namespace: sveltosNamespace, Name: "sveltos-agent-manager"},
 				currentSveltosAgent)
 		}, timeout, pollingInterval).Should(BeNil())
 	})
@@ -605,7 +605,7 @@ var _ = Describe("Classifier Deployer", func() {
 		Eventually(func() bool {
 			secret := &corev1.Secret{}
 			err := testEnv.Get(context.TODO(),
-				types.NamespacedName{Namespace: libsveltosv1beta1.ClassifierSecretNamespace, Name: libsveltosv1beta1.ClassifierSecretName},
+				types.NamespacedName{Namespace: sveltosNamespace, Name: libsveltosv1beta1.ClassifierSecretName},
 				secret)
 			return err == nil
 		}, timeout, pollingInterval).Should(BeTrue())
@@ -625,7 +625,7 @@ var _ = Describe("Classifier Deployer", func() {
 		expectedLabels := controllers.GetSveltosAgentLabels(clusterNamespace, clusterName, clusterType)
 
 		listOptions := []client.ListOption{
-			client.InNamespace(controllers.GetSveltosAgentNamespace()),
+			client.InNamespace(controllers.GetSveltosAgentNamespace(sveltosNamespace)),
 		}
 		Eventually(func() bool {
 			deployments := &appsv1.DeploymentList{}
@@ -675,7 +675,7 @@ var _ = Describe("Classifier Deployer", func() {
 			},
 		}
 
-		cmYAML := `apiVersion: v1
+		cmYAML := fmt.Sprintf(`apiVersion: v1
 data:
   deployment-patch: |-
       patch: |-
@@ -694,7 +694,7 @@ data:
       target:
         kind: Deployment
         name: sveltos-agent-manager
-        namespace: projectsveltos
+        namespace: %s
   clusterrole-patch: |-
       patch: |-
         - op: remove
@@ -705,7 +705,7 @@ data:
 kind: ConfigMap
 metadata:
   name: sveltos-agent-config
-  namespace: projectsveltos`
+  namespace: %s`, sveltosNamespace, sveltosNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -735,7 +735,7 @@ metadata:
 			},
 		}
 
-		cmYAML := `apiVersion: v1
+		cmYAML := fmt.Sprintf(`apiVersion: v1
 data:
   deployment-patch: |-
       patch: |-
@@ -748,7 +748,7 @@ data:
       target:
         kind: Deployment
         name: sveltos-applier-manager
-        namespace: projectsveltos
+        namespace: %s
   clusterrole-patch: |-
       patch: |-
         - op: remove
@@ -759,7 +759,7 @@ data:
 kind: ConfigMap
 metadata:
   name: sveltos-applier-config
-  namespace: projectsveltos`
+  namespace: %s`, sveltosNamespace, sveltosNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -814,7 +814,7 @@ data:
       target:
         kind: Deployment
         name: sveltos-agent-manager
-        namespace: projectsveltos
+        namespace: %s
   clusterrole-patch: |-
       patch: |-
         - op: remove
@@ -825,7 +825,7 @@ data:
 kind: ConfigMap
 metadata:
   name: %s
-  namespace: %s`, configMapName, configMapNamespace)
+  namespace: %s`, sveltosNamespace, configMapName, configMapNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -874,7 +874,7 @@ data:
       target:
         kind: Deployment
         name: sveltos-applier-manager
-        namespace: projectsveltos
+        namespace: %s
   clusterrole-patch: |-
       patch: |-
         - op: remove
@@ -885,7 +885,7 @@ data:
 kind: ConfigMap
 metadata:
   name: %s
-  namespace: %s`, configMapName, configMapNamespace)
+  namespace: %s`, sveltosNamespace, configMapName, configMapNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -915,7 +915,7 @@ metadata:
 			},
 		}
 
-		cmYAML := `apiVersion: v1
+		cmYAML := fmt.Sprintf(`apiVersion: v1
 data:
   deployment-spec-patch: |-
     patch: |-
@@ -938,7 +938,7 @@ data:
 kind: ConfigMap
 metadata:
   name: sveltos-agent-config
-  namespace: projectsveltos`
+  namespace: %s`, sveltosNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -968,7 +968,7 @@ metadata:
 			},
 		}
 
-		cmYAML := `apiVersion: v1
+		cmYAML := fmt.Sprintf(`apiVersion: v1
 data:
   deployment-patch: |-
             image-patch: |-
@@ -994,7 +994,7 @@ data:
 kind: ConfigMap
 metadata:
   name: sveltos-agent-config-old
-  namespace: projectsveltos`
+  namespace: %s`, sveltosNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -1022,7 +1022,7 @@ metadata:
 			},
 		}
 
-		cmYAML := `apiVersion: v1
+		cmYAML := fmt.Sprintf(`apiVersion: v1
 data:
   patch: |-
     apiVersion: apps/v1
@@ -1040,7 +1040,7 @@ data:
 kind: ConfigMap
 metadata:
   name: sveltos-agent-config-old
-  namespace: projectsveltos`
+  namespace: %s`, sveltosNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -1126,7 +1126,7 @@ func prepareCluster() *clusterv1.Cluster {
 	By("Create the ConfigMap with sveltos-agent version")
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: projectsveltosNamespace,
+			Namespace: sveltosNamespace,
 			Name:      "sveltos-agent-version",
 		},
 		Data: map[string]string{

--- a/controllers/classifier_predicates.go
+++ b/controllers/classifier_predicates.go
@@ -234,7 +234,7 @@ func ConfigMapPredicates(logger logr.Logger) predicate.Funcs {
 }
 
 func isConfigMapWithPatches(cm *corev1.ConfigMap) bool {
-	if cm.Namespace == projectsveltos && cm.Name == getSveltosAgentConfigMap() {
+	if cm.Namespace == getSveltosNamespace() && cm.Name == getSveltosAgentConfigMap() {
 		return true
 	}
 

--- a/controllers/classifier_predicates_test.go
+++ b/controllers/classifier_predicates_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Classifier Predicates: ConfigMapPredicates", func() {
 
 		configMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "projectsveltos",
+				Namespace: sveltosNamespace,
 				Name:      randomString(),
 			},
 		}

--- a/controllers/classifier_report_collection.go
+++ b/controllers/classifier_report_collection.go
@@ -323,8 +323,8 @@ func processClassifierReportsForClusterInAgentlessMode(ctx context.Context, c cl
 		return nil
 	}
 
-	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, getManagementClusterClient(), version, ref.Namespace,
-		ref.Name, clusterproxy.GetClusterType(ref), true, logger) {
+	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, getManagementClusterClient(), getSveltosNamespace(),
+		version, ref.Namespace, ref.Name, clusterproxy.GetClusterType(ref), true, logger) {
 
 		logger.V(logs.LogDebug).Info(compatibilityCheckErrorMsg)
 		return errors.New(compatibilityCheckErrorMsg)
@@ -399,8 +399,8 @@ func collectClassifierReportsFromCluster(ctx context.Context, c client.Client,
 		return nil
 	}
 
-	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, getManagementClusterClient(), version, cluster.Namespace,
-		cluster.Name, clusterproxy.GetClusterType(cluster), getAgentInMgmtCluster(), logger) {
+	if !sveltos_upgrade.IsSveltosAgentVersionCompatible(ctx, getManagementClusterClient(), getSveltosNamespace(), version,
+		cluster.Namespace, cluster.Name, clusterproxy.GetClusterType(cluster), getAgentInMgmtCluster(), logger) {
 
 		logger.V(logs.LogDebug).Info(compatibilityCheckErrorMsg)
 		return errors.New(compatibilityCheckErrorMsg)

--- a/controllers/classifier_report_collection_test.go
+++ b/controllers/classifier_report_collection_test.go
@@ -181,10 +181,9 @@ var _ = Describe("Classifier Deployer", func() {
 
 		// In managed cluster this is the namespace where ClassifierReports
 		// are created
-		const classifierReportNamespace = "projectsveltos"
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: classifierReportNamespace,
+				Name: sveltosNamespace,
 			},
 		}
 		err := testEnv.Create(context.TODO(), ns)
@@ -199,7 +198,7 @@ var _ = Describe("Classifier Deployer", func() {
 		Expect(waitForObject(context.TODO(), testEnv.Client, classifier)).To(Succeed())
 
 		classifierReport := getClassifierReport(classifierName, "", "")
-		classifierReport.Namespace = classifierReportNamespace
+		classifierReport.Namespace = sveltosNamespace
 		Expect(testEnv.Create(context.TODO(), classifierReport)).To(Succeed())
 
 		Expect(waitForObject(context.TODO(), testEnv.Client, classifierReport)).To(Succeed())

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -52,10 +52,11 @@ import (
 )
 
 var (
-	testEnv *helpers.TestEnvironment
-	cancel  context.CancelFunc
-	ctx     context.Context
-	scheme  *runtime.Scheme
+	testEnv          *helpers.TestEnvironment
+	cancel           context.CancelFunc
+	ctx              context.Context
+	scheme           *runtime.Scheme
+	sveltosNamespace string
 )
 
 var (
@@ -71,7 +72,6 @@ const (
 	upstreamClusterNamePrefix = "upstream-cluster"
 	upstreamMachineNamePrefix = "upstream-machine"
 	clusterKind               = "Cluster"
-	projectsveltosNamespace   = "projectsveltos"
 )
 
 const (
@@ -102,6 +102,8 @@ var _ = BeforeSuite(func() {
 		panic(err)
 	}
 
+	sveltosNamespace = randomString()
+	controllers.SetSveltosNamespace(sveltosNamespace)
 	controllers.SetManagementClusterAccess(testEnv.Config, testEnv.Client)
 	controllers.CreatFeatureHandlerMaps()
 
@@ -127,7 +129,7 @@ var _ = BeforeSuite(func() {
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: projectsveltosNamespace,
+			Name: sveltosNamespace,
 		},
 	}
 	Expect(testEnv.Create(ctx, ns)).To(Succeed())

--- a/controllers/management_cluster.go
+++ b/controllers/management_cluster.go
@@ -30,6 +30,7 @@ var (
 	registry                string
 	agentInMgmtCluster      bool
 	enableNatsWatcher       bool
+	sveltosNamespace        string
 )
 
 func SetManagementClusterAccess(config *rest.Config, c client.Client) {
@@ -55,6 +56,10 @@ func SetAgentInMgmtCluster(isInMgmtCluster bool) {
 
 func SetSveltosAgentEnableNATS(enable bool) {
 	enableNatsWatcher = enable
+}
+
+func SetSveltosNamespace(ns string) {
+	sveltosNamespace = ns
 }
 
 func getManagementClusterConfig() *rest.Config {
@@ -87,4 +92,8 @@ func getAgentInMgmtCluster() bool {
 
 func getSveltosAgentEnableNATS() bool {
 	return enableNatsWatcher
+}
+
+func getSveltosNamespace() string {
+	return sveltosNamespace
 }

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -30,7 +30,7 @@ import (
 var (
 	programClassifierDurationHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Namespace: "projectsveltos",
+			Namespace: getSveltosNamespace(),
 			Name:      "program_classifier_time_seconds",
 			Help:      "Program Classifier on a workload cluster duration distribution",
 			Buckets:   []float64{0.1, 0.5, 1, 5, 10, 20, 30},

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.10.0
+	github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v1.10.0 h1:+Gk34qCEOryHMT7xDFSIniiqk3VymhiKs/3EdK5gJ58=
-github.com/projectsveltos/libsveltos v1.10.0/go.mod h1:AzKBiyMTL3KSTLYMii5QdR3ieWyUKBHZCMFWIVCfm6A=
+github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f h1:XrgpnRRH59AwSkSEIcKPUDpAME0Sl4sXLeEhDIaYQMU=
+github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f/go.mod h1:AzKBiyMTL3KSTLYMii5QdR3ieWyUKBHZCMFWIVCfm6A=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -111,18 +112,7 @@ func main() {
 
 	reportMode = controllers.ReportMode(tmpReportMode)
 
-	ctrlOptions := ctrl.Options{
-		Scheme:                 scheme,
-		Metrics:                getDiagnosticsOptions(),
-		HealthProbeBindAddress: healthAddr,
-		WebhookServer: webhook.NewServer(
-			webhook.Options{
-				Port: webhookPort,
-			}),
-		Cache: cache.Options{
-			SyncPeriod: &syncPeriod,
-		},
-	}
+	ctrlOptions := getCtrlOptions(scheme)
 
 	restConfig := ctrl.GetConfigOrDie()
 	restConfig.QPS = restConfigQPS
@@ -134,11 +124,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	sveltosNamespace := getSveltosNamespace()
+
 	controllers.SetManagementClusterAccess(mgr.GetConfig(), mgr.GetClient())
 	controllers.SetSveltosAgentConfigMap(sveltosAgentConfigMap)
 	controllers.SetSveltosApplierConfigMap(sveltosApplierConfigMap)
 	controllers.SetSveltosAgentRegistry(registry)
 	controllers.SetAgentInMgmtCluster(agentInMgmtCluster)
+	controllers.SetSveltosNamespace(sveltosNamespace)
 
 	setupLog.V(logs.LogInfo).Info(fmt.Sprintf("Running in managemnt cluster: %t", agentInMgmtCluster))
 
@@ -171,13 +164,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.SveltosClusterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SveltosCluster")
-		os.Exit(1)
-	}
+	startSveltosClusterReconciler(mgr)
 	//+kubebuilder:scaffold:builder
 
 	setupChecks(mgr)
@@ -382,4 +369,38 @@ func getDiagnosticsOptions() metricsserver.Options {
 		SecureServing:  true,
 		FilterProvider: filters.WithAuthenticationAndAuthorization,
 	}
+}
+
+func getCtrlOptions(scheme *runtime.Scheme) ctrl.Options {
+	return ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                getDiagnosticsOptions(),
+		HealthProbeBindAddress: healthAddr,
+		WebhookServer: webhook.NewServer(
+			webhook.Options{
+				Port: webhookPort,
+			}),
+		Cache: cache.Options{
+			SyncPeriod: &syncPeriod,
+		},
+	}
+}
+
+func startSveltosClusterReconciler(mgr manager.Manager) {
+	if err := (&controllers.SveltosClusterReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SveltosCluster")
+		os.Exit(1)
+	}
+}
+
+func getSveltosNamespace() string {
+	sveltosNamespace := os.Getenv("NAMESPACE")
+	if sveltosNamespace == "" {
+		setupLog.V(logs.LogInfo).Error(nil, "Missing required environment variables NAMESPACE")
+		os.Exit(1)
+	}
+	return sveltosNamespace
 }

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -24,12 +24,25 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.10.0
+        env:
+        - name: TOTAL_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,12 +24,25 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.10.0
+        env:
+        - name: TOTAL_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -168,12 +168,25 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
-        image: docker.io/projectsveltos/classifier:v1.10.0
+        env:
+        - name: TOTAL_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.go
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.go
@@ -42,7 +42,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.10.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -58,7 +58,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:7f0d411ca1312672e8c5b2a6a1ce31f1c86b31781061012d3f6b5c52f8f5229a
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/sveltos-agent@sha256:7a5c4179279be399a0a492f488a078ff4f36394dd264118ba6f56c2b4b8817b1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
@@ -24,7 +24,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.10.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -40,7 +40,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:7f0d411ca1312672e8c5b2a6a1ce31f1c86b31781061012d3f6b5c52f8f5229a
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/sveltos-agent@sha256:7a5c4179279be399a0a492f488a078ff4f36394dd264118ba6f56c2b4b8817b1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.go
+++ b/pkg/agent/sveltos-agent.go
@@ -201,7 +201,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.10.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -217,7 +217,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:7f0d411ca1312672e8c5b2a6a1ce31f1c86b31781061012d3f6b5c52f8f5229a
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/sveltos-agent@sha256:7a5c4179279be399a0a492f488a078ff4f36394dd264118ba6f56c2b4b8817b1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.yaml
+++ b/pkg/agent/sveltos-agent.yaml
@@ -183,7 +183,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.10.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -199,7 +199,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/sveltos-agent@sha256:7f0d411ca1312672e8c5b2a6a1ce31f1c86b31781061012d3f6b5c52f8f5229a
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/sveltos-agent@sha256:7a5c4179279be399a0a492f488a078ff4f36394dd264118ba6f56c2b4b8817b1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-applier.go
+++ b/pkg/agent/sveltos-applier.go
@@ -101,11 +101,11 @@ spec:
         - --cluster-type=
         - --secret-with-kubeconfig=
         - --v=5
-        - --version=v1.9.0
+        - --version=main
         command:
         - /manager
         env:
-        - name: GOMEMLIMIT
+        - name: TOTAL_MEMORY_LIMIT
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
@@ -117,7 +117,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier:v1.9.0
+        image: docker.io/projectsveltos/sveltos-applier@sha256:9e7170faec7d9bf58c857d193f9c682f286eef20c3875a9a05a71fb74cf203e3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-applier.yaml
+++ b/pkg/agent/sveltos-applier.yaml
@@ -83,11 +83,11 @@ spec:
         - --cluster-type=
         - --secret-with-kubeconfig=
         - --v=5
-        - --version=v1.9.0
+        - --version=main
         command:
         - /manager
         env:
-        - name: GOMEMLIMIT
+        - name: TOTAL_MEMORY_LIMIT
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier:v1.9.0
+        image: docker.io/projectsveltos/sveltos-applier@sha256:9e7170faec7d9bf58c857d193f9c682f286eef20c3875a9a05a71fb74cf203e3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/fv/deploy_test.go
+++ b/test/fv/deploy_test.go
@@ -187,7 +187,7 @@ func verifySveltosAgent(workloadClient client.Client, name string) {
 	Eventually(func() bool {
 		depl := &appsv1.Deployment{}
 		err := workloadClient.Get(context.TODO(),
-			types.NamespacedName{Namespace: "projectsveltos", Name: name}, depl)
+			types.NamespacedName{Namespace: deplNamespace, Name: name}, depl)
 		if err != nil {
 			return false
 		}

--- a/test/fv/fv_suite_test.go
+++ b/test/fv/fv_suite_test.go
@@ -19,6 +19,7 @@ package fv_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -50,7 +51,8 @@ var (
 	k8sClient           client.Client
 	scheme              *runtime.Scheme
 	kindWorkloadCluster *unstructured.Unstructured // This is the name of the kind workload cluster, in the form namespace/name
-
+	deplNamespace       string
+	configMapConfig     string
 )
 
 const (
@@ -59,13 +61,17 @@ const (
 )
 
 const (
-	deplNamespace        = "projectsveltos"
 	deplName             = "classifier-manager"
 	managerContainerName = "manager"
 )
 
-var (
-	configMapConfig = `    apiVersion: v1
+func init() {
+	deplNamespace = os.Getenv("SVELTOS_NAMESPACE")
+	if deplNamespace == "" {
+		deplNamespace = "projectsveltos"
+	}
+
+	configMapConfig = fmt.Sprintf(`    apiVersion: v1
     data:
       patch: |-
         apiVersion: apps/v1
@@ -83,8 +89,8 @@ var (
     kind: ConfigMap
     metadata:
       name: sveltos-agent
-      namespace: projectsveltos`
-)
+      namespace: %s`, deplNamespace)
+}
 
 func TestFv(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -112,6 +118,7 @@ func TestFv(t *testing.T) {
 }
 
 var _ = SynchronizedBeforeSuite(func() []byte {
+	By(fmt.Sprintf("Running with Sveltos namespace: %s", deplNamespace))
 	ctrl.SetLogger(klog.Background())
 
 	restConfig := ctrl.GetConfigOrDie()

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -83,11 +83,11 @@ spec:
         - --cluster-type=sveltos
         - --secret-with-kubeconfig=clusterapi-workload-sveltos-kubeconfig
         - --v=5
-        - --version=v1.9.0
+        - --version=main
         command:
         - /manager
         env:
-        - name: GOMEMLIMIT
+        - name: TOTAL_MEMORY_LIMIT
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier:v1.9.0
+        image: docker.io/projectsveltos/sveltos-applier@sha256:9e7170faec7d9bf58c857d193f9c682f286eef20c3875a9a05a71fb74cf203e3
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Historically, the Sveltos namespace has been hardcoded/fixed to `projectsveltos`.
This PR is part of series that will remove this limitation.