### PR TITLE
(feat) Move Classifier status to ClassifierReports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,13 @@ RUN go mod download
 
 # Copy the go source
 COPY main.go main.go
+COPY migration.go migration.go
 COPY controllers/ controllers/
 COPY internal/ internal/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=$BUILDOS GOARCH=$TARGETARCH go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=$BUILDOS GOARCH=$TARGETARCH go build -a -o manager .
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
+PULL_POLICY ?= IfNotPresent
 # KUBEBUILDER_ENVTEST_KUBERNETES_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 KUBEBUILDER_ENVTEST_KUBERNETES_VERSION = 1.35.0
 
@@ -343,7 +344,7 @@ delete-cluster: $(KIND) ## Deletes the kind cluster $(CONTROL_CLUSTER_NAME)
 
 .PHONY: build
 build: sveltos-agent generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -o bin/manager .
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -32,3 +32,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      initContainers:
+      - name: migrate
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: IS_INITIALIZATION
+          value: "true"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - image: docker.io/projectsveltos/classifier:main
+        name: migrate
       containers:
       # Change the value of image field below to your controller image URL
       - image: docker.io/projectsveltos/classifier:main

--- a/config/default/manager_pull_policy.yaml
+++ b/config/default/manager_pull_policy.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: migrate
+        imagePullPolicy: IfNotPresent
       containers:
       - name: manager
-        imagePullPolicy: 
+        imagePullPolicy: IfNotPresent

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,27 @@ spec:
         # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
         # seccompProfile:
         #   type: RuntimeDefault
+      initContainers:
+      - name: migrate
+        command:
+        - /manager
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: IS_INITIALIZATION
+          value: "true"
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
       containers:
       - command:
         - /manager
@@ -38,7 +59,7 @@ spec:
         - --report-mode=1
         - --v=5
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         ports:
         - containerPort: 8443
@@ -76,6 +97,6 @@ spec:
             memory: 512Mi
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
       serviceAccountName: classifier-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -87,16 +87,17 @@ rules:
 - apiGroups:
   - lib.projectsveltos.io
   resources:
-  - classifiers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
+  - classifierreports/status
   - classifiers/status
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - classifiers/finalizers
+  verbs:
   - update
 - apiGroups:
   - lib.projectsveltos.io

--- a/controllers/classifier_controller.go
+++ b/controllers/classifier_controller.go
@@ -122,6 +122,7 @@ type ClassifierReconciler struct {
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=classifiers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=classifiers/finalizers,verbs=update
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=classifierreports,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=classifierreports/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=accessrequests,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=configurationgroups,verbs=get;list;watch;create;delete;update;patch
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=configurationgroups/status,verbs=get;list;watch
@@ -290,26 +291,29 @@ func (r *ClassifierReconciler) reconcileNormal(
 	}
 
 	// For every currently matching cluster, update label ownership registrations
-	err = r.updateMatchingClustersAndRegistrations(ctx, classifierScope, matchingClusters, logger)
+	matchingStatuses, err := r.updateMatchingClustersAndRegistrations(ctx, classifierScope, matchingClusters, logger)
 	if err != nil {
 		logger.V(logs.LogDebug).Error(err, "failed to update status/registrations for matching clusters")
 		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}, nil
 	}
 
 	// Apply the labels to the clusters
-	err = r.updateLabelsOnMatchingClusters(ctx, classifierScope, logger)
+	err = r.updateLabelsOnMatchingClusters(ctx, classifierScope, matchingStatuses, logger)
 	if err != nil {
 		logger.V(logs.LogDebug).Error(err, "failed to apply labels to matching clusters")
 		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}, nil
 	}
 
-	err = r.updateClusterInfo(ctx, classifierScope)
+	err = r.ensureClassifierReports(ctx, classifierScope)
 	if err != nil {
-		logger.V(logs.LogDebug).Error(err, "failed to update clusterInfo")
+		logger.V(logs.LogDebug).Error(err, "failed to ensure ClassifierReports")
 		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}, nil
 	}
 
-	r.updateMaps(classifierScope)
+	if err := r.updateMaps(ctx, classifierScope); err != nil {
+		logger.V(logs.LogDebug).Error(err, "failed to update internal maps")
+		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}, nil
+	}
 
 	f := getHandlersForFeature(libsveltosv1beta1.FeatureClassifier)
 
@@ -318,7 +322,7 @@ func (r *ClassifierReconciler) reconcileNormal(
 		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}, nil
 	}
 
-	if hasUnManagedLabels(classifierScope.Classifier) {
+	if hasUnManagedLabels(matchingStatuses) {
 		return reconcile.Result{Requeue: true, RequeueAfter: conflictRequeueAfter}, nil
 	}
 
@@ -421,41 +425,22 @@ func (r *ClassifierReconciler) addFinalizer(ctx context.Context, classifierScope
 	return nil
 }
 
-// updateClusterInfo updates Classifier Status ClusterInfo by adding an entry for any
-// new cluster where Classifier needs to be deployed
-func (r *ClassifierReconciler) updateClusterInfo(ctx context.Context, classifierScope *scope.ClassifierScope) error {
-	classifier := classifierScope.Classifier
-
-	getClusterID := func(cluster corev1.ObjectReference) string {
-		return fmt.Sprintf("%s:%s/%s", clusterproxy.GetClusterType(&cluster), cluster.Namespace, cluster.Name)
-	}
-
-	matchingCluster, err := clusterproxy.GetListOfClusters(ctx, r.Client, "", r.CapiOnboardAnnotation,
+// ensureClassifierReports creates a ClassifierReport in the management cluster for every known
+// cluster that does not already have one. The report is initialized with Match=false; the agent
+// updates Spec.Match on its next reconcile cycle.
+func (r *ClassifierReconciler) ensureClassifierReports(ctx context.Context, classifierScope *scope.ClassifierScope) error {
+	allClusters, err := clusterproxy.GetListOfClusters(ctx, r.Client, "", r.CapiOnboardAnnotation,
 		classifierScope.Logger)
 	if err != nil {
 		return err
 	}
 
-	// Build Map for all Clusters with an entry in Classifier.Status.ClusterInfo
-	clusterMap := make(map[string]bool)
-	for i := range classifier.Status.ClusterInfo {
-		c := &classifier.Status.ClusterInfo[i]
-		clusterMap[getClusterID(c.Cluster)] = true
-	}
-
-	newClusterInfo := make([]libsveltosv1beta1.ClusterInfo, 0)
-	for i := range matchingCluster {
-		c := matchingCluster[i]
-		if _, ok := clusterMap[getClusterID(c)]; !ok {
-			newClusterInfo = append(newClusterInfo, libsveltosv1beta1.ClusterInfo{
-				Cluster: c,
-			})
+	for i := range allClusters {
+		if err := ensureClassifierReportForCluster(ctx, r.Client, classifierScope.Classifier.Name,
+			&allClusters[i]); err != nil {
+			return err
 		}
 	}
-
-	finalClusterInfo := classifier.Status.ClusterInfo
-	finalClusterInfo = append(finalClusterInfo, newClusterInfo...)
-	classifierScope.SetClusterInfo(finalClusterInfo)
 	return nil
 }
 
@@ -513,15 +498,16 @@ func (r *ClassifierReconciler) syncAndGetMatchingClusters(ctx context.Context,
 	return currentMatchingClusters, nil
 }
 
-// updateMatchingClustersAndRegistrations synchronizes the KeyManager registrations
-// and updates the Classifier's Status with the current set of matching clusters.
+// updateMatchingClustersAndRegistrations synchronizes the KeyManager registrations,
+// writes managed/unmanaged label data into each matching cluster's ClassifierReport.Status,
+// and returns the in-memory slice for use by the caller within the same reconcile cycle.
 func (r *ClassifierReconciler) updateMatchingClustersAndRegistrations(ctx context.Context,
 	classifierScope *scope.ClassifierScope, matchingClusters map[corev1.ObjectReference]bool,
-	logger logr.Logger) error {
+	logger logr.Logger) ([]libsveltosv1beta1.MachingClusterStatus, error) {
 
 	// Sync registrations first so classifyLabels knows what we are allowed to manage
 	if err := r.registerMatchingClusters(ctx, classifierScope.Classifier, matchingClusters, logger); err != nil {
-		return fmt.Errorf("failed to register labels with keymanager: %w", err)
+		return nil, fmt.Errorf("failed to register labels with keymanager: %w", err)
 	}
 
 	matchingClusterStatus := make([]libsveltosv1beta1.MachingClusterStatus, 0, len(matchingClusters))
@@ -530,11 +516,17 @@ func (r *ClassifierReconciler) updateMatchingClustersAndRegistrations(ctx contex
 	for c := range matchingClusters {
 		managed, unmanaged, err := r.classifyLabels(ctx, classifierScope.Classifier, &c, logger)
 		if err != nil {
-			return fmt.Errorf("failed to classify labels for cluster %s/%s: %w", c.Namespace, c.Name, err)
+			return nil, fmt.Errorf("failed to classify labels for cluster %s/%s: %w", c.Namespace, c.Name, err)
 		}
 
 		if len(unmanaged) > 0 {
 			hasUnmanaged = true
+		}
+
+		if err := updateClassifierReportLabelStatus(ctx, r.Client, classifierScope.Classifier.Name,
+			&c, managed, unmanaged); err != nil {
+			return nil, fmt.Errorf("failed to update ClassifierReport label status for cluster %s/%s: %w",
+				c.Namespace, c.Name, err)
 		}
 
 		matchingClusterStatus = append(matchingClusterStatus, libsveltosv1beta1.MachingClusterStatus{
@@ -544,28 +536,34 @@ func (r *ClassifierReconciler) updateMatchingClustersAndRegistrations(ctx contex
 		})
 	}
 
-	// updateClassifierSet likely updates a boolean if any cluster has label conflicts
 	r.updateClassifierSet(classifierScope, hasUnmanaged)
-	classifierScope.SetMachingClusterStatuses(matchingClusterStatus)
-
-	return nil
+	return matchingClusterStatus, nil
 }
 
 func (r *ClassifierReconciler) cleanUpManagedResources(ctx context.Context,
 	classifierScope *scope.ClassifierScope, matchingClusters map[corev1.ObjectReference]bool,
 	logger logr.Logger) error {
 
-	// create map of old matching clusters from the Classifier Status
-	oldMatchingClusters := make(map[corev1.ObjectReference]bool)
-	for i := range classifierScope.Classifier.Status.MachingClusterStatuses {
-		ref := classifierScope.Classifier.Status.MachingClusterStatuses[i]
-		oldMatchingClusters[ref.ClusterRef] = true
+	// Build the set of clusters we previously applied labels to by reading ClassifierReport.Status.
+	// Any cluster with non-empty ManagedLabels or UnManagedLabels was processed in a prior reconcile.
+	reports, err := listClassifierReportsForClassifier(ctx, r.Client, classifierScope.Classifier.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list ClassifierReports: %w", err)
 	}
 
-	// Identify and clean up clusters that are no longer matches.
-	// This will remove managed labels from the clusters and, if successful,
-	// clear the registrations from the KeyManager.
-	err := r.cleanUpNonMatchingClusters(ctx, classifierScope.Classifier,
+	oldMatchingClusters := make(map[corev1.ObjectReference]bool)
+	for i := range reports {
+		report := &reports[i]
+		if report.Spec.ClusterNamespace == "" {
+			continue
+		}
+		if len(report.Status.ManagedLabels) > 0 || len(report.Status.UnManagedLabels) > 0 {
+			cluster := getClusterRefFromClassifierReport(report)
+			oldMatchingClusters[*cluster] = true
+		}
+	}
+
+	err = r.cleanUpNonMatchingClusters(ctx, classifierScope.Classifier,
 		matchingClusters, oldMatchingClusters, logger)
 	if err != nil {
 		return fmt.Errorf("failed to clean up non-matching clusters: %w", err)
@@ -591,10 +589,10 @@ func (r *ClassifierReconciler) updateClassifierSet(classifierScope *scope.Classi
 // updateLabelsOnMatchingClusters applies the desired labels to all clusters
 // currently matching the Classifier, skipping clusters that are not found.
 func (r *ClassifierReconciler) updateLabelsOnMatchingClusters(ctx context.Context,
-	classifierScope *scope.ClassifierScope, logger logr.Logger) error {
+	classifierScope *scope.ClassifierScope,
+	statuses []libsveltosv1beta1.MachingClusterStatus, logger logr.Logger) error {
 
 	var errs []error
-	statuses := classifierScope.Classifier.Status.MachingClusterStatuses
 
 	for i := range statuses {
 		ref := &statuses[i].ClusterRef
@@ -693,10 +691,25 @@ func (r *ClassifierReconciler) updateLabelsOnCluster(ctx context.Context,
 	return r.Update(ctx, cluster)
 }
 
-func (r *ClassifierReconciler) updateMaps(classifierScope *scope.ClassifierScope) {
+func (r *ClassifierReconciler) updateMaps(ctx context.Context, classifierScope *scope.ClassifierScope) error {
+	reports, err := listClassifierReportsForClassifier(ctx, r.Client, classifierScope.Classifier.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list ClassifierReports for map update: %w", err)
+	}
+
 	currentClusters := &libsveltosset.Set{}
-	for i := range classifierScope.Classifier.Status.ClusterInfo {
-		currentClusters.Insert(&classifierScope.Classifier.Status.ClusterInfo[i].Cluster)
+	for i := range reports {
+		report := &reports[i]
+		if report.Spec.ClusterNamespace == "" {
+			continue
+		}
+		if report.Status.DeploymentStatus != nil &&
+			*report.Status.DeploymentStatus == libsveltosv1beta1.SveltosStatusRemoved {
+
+			continue
+		}
+		cluster := getClusterRefFromClassifierReport(report)
+		currentClusters.Insert(cluster)
 	}
 
 	r.Mux.Lock()
@@ -704,41 +717,52 @@ func (r *ClassifierReconciler) updateMaps(classifierScope *scope.ClassifierScope
 
 	classifierInfo := getKeyFromObject(r.Scheme, classifierScope.Classifier)
 
-	// Get list of Clusters not matched anymore by Classifier
 	var toBeRemoved []corev1.ObjectReference
 	if v, ok := r.ClassifierMap[*classifierInfo]; ok {
 		toBeRemoved = v.Difference(currentClusters)
 	}
 
-	// For each currently matching Cluster, add Classifier as consumer
-	for i := range classifierScope.Classifier.Status.ClusterInfo {
-		clusterInfo := &classifierScope.Classifier.Status.ClusterInfo[i].Cluster
-		r.getClusterMapForEntry(clusterInfo).Insert(classifierInfo)
+	for i := range reports {
+		report := &reports[i]
+		if report.Spec.ClusterNamespace == "" {
+			continue
+		}
+		if report.Status.DeploymentStatus != nil &&
+			*report.Status.DeploymentStatus == libsveltosv1beta1.SveltosStatusRemoved {
+
+			continue
+		}
+		cluster := getClusterRefFromClassifierReport(report)
+		r.getClusterMapForEntry(cluster).Insert(classifierInfo)
 	}
 
-	// For each Cluster not matched anymore, remove Classifier as consumer
 	for i := range toBeRemoved {
 		clusterName := toBeRemoved[i]
 		r.getClusterMapForEntry(&clusterName).Erase(classifierInfo)
 	}
 
-	// Update list of Cluster currently a match for a Classifier
 	r.ClassifierMap[*classifierInfo] = currentClusters
+	return nil
 }
 
-// removeLabelsFromClusters identifies all clusters currently matching the Classifier's
-// selector and removes labels managed by this Classifier instance from each of them.
-// It continues processing remaining clusters even if an individual cluster update fails,
-// returning a combined error at the end.
+// removeLabelsFromClusters removes labels managed by this Classifier from every cluster
+// that has ManagedLabels tracked in its ClassifierReport.Status.
 func (r *ClassifierReconciler) removeLabelsFromClusters(ctx context.Context,
 	classifierScope *scope.ClassifierScope, logger logr.Logger) error {
 
+	reports, err := listClassifierReportsForClassifier(ctx, r.Client, classifierScope.Classifier.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list ClassifierReports: %w", err)
+	}
+
 	var errs []error
+	for i := range reports {
+		report := &reports[i]
+		if report.Spec.ClusterNamespace == "" || len(report.Status.ManagedLabels) == 0 {
+			continue
+		}
 
-	// Iterate through all clusters currently tracked in the Classifier status
-	for i := range classifierScope.Classifier.Status.MachingClusterStatuses {
-		ref := &classifierScope.Classifier.Status.MachingClusterStatuses[i].ClusterRef
-
+		ref := getClusterRefFromClassifierReport(report)
 		cluster, err := clusterproxy.GetCluster(ctx, r.Client, ref.Namespace, ref.Name,
 			clusterproxy.GetClusterType(ref))
 		if err != nil {
@@ -755,10 +779,8 @@ func (r *ClassifierReconciler) removeLabelsFromClusters(ctx context.Context,
 			"cluster", fmt.Sprintf("%s/%s", cluster.GetNamespace(), cluster.GetName()),
 			"clusterType", clusterproxy.GetClusterType(ref),
 		)
-
 		clusterLogger.V(logs.LogDebug).Info("removing managed labels from cluster")
 
-		// Remove labels and collect error if the operation fails
 		if err := r.removeLabelsFromCluster(ctx, classifierScope.Classifier, cluster,
 			clusterproxy.GetClusterType(ref), clusterLogger); err != nil {
 			clusterLogger.Error(err, "failed to remove labels")
@@ -769,8 +791,7 @@ func (r *ClassifierReconciler) removeLabelsFromClusters(ctx context.Context,
 	return errors.Join(errs...)
 }
 
-// removeAllRegistrations unregisters Classifier for all cluster labels
-// it used to manage (in any matching cluster)
+// removeAllRegistrations unregisters Classifier for all cluster labels it was managing.
 func (r *ClassifierReconciler) removeAllRegistrations(ctx context.Context,
 	classifierScope *scope.ClassifierScope, logger logr.Logger,
 ) error {
@@ -781,8 +802,17 @@ func (r *ClassifierReconciler) removeAllRegistrations(ctx context.Context,
 		return err
 	}
 
-	for i := range classifierScope.Classifier.Status.MachingClusterStatuses {
-		c := &classifierScope.Classifier.Status.MachingClusterStatuses[i].ClusterRef
+	reports, err := listClassifierReportsForClassifier(ctx, r.Client, classifierScope.Classifier.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list ClassifierReports: %w", err)
+	}
+
+	for i := range reports {
+		report := &reports[i]
+		if report.Spec.ClusterNamespace == "" {
+			continue
+		}
+		c := getClusterRefFromClassifierReport(report)
 		manager.RemoveAllRegistrations(classifierScope.Classifier, c.Namespace, c.Name, clusterproxy.GetClusterType(c))
 	}
 
@@ -863,6 +893,12 @@ func (r *ClassifierReconciler) cleanUpNonMatchingClusters(ctx context.Context,
 
 		// 3. Only remove registrations if label removal was successful
 		manager.RemoveAllRegistrations(classifier, c.Namespace, c.Name, clusterType)
+
+		// 4. Clear label tracking from ClassifierReport.Status now that labels are removed.
+		if err := updateClassifierReportLabelStatus(ctx, r.Client, classifier.Name, &c, nil, nil); err != nil {
+			clusterLogger.Error(err, "failed to clear ClassifierReport label status")
+			errs = append(errs, err)
+		}
 	}
 
 	return errors.Join(errs...)
@@ -922,14 +958,12 @@ func startSveltosAgentInMgmtCluster(o deployer.Options) bool {
 	return runInMgtmCluster
 }
 
-// hasUnManagedLabels returns true if there is a conflict where this classifier
-// wants to manage labels that are already being managed by another instance.
-func hasUnManagedLabels(classifier *libsveltosv1beta1.Classifier) bool {
-	for i := range classifier.Status.MachingClusterStatuses {
-		if len(classifier.Status.MachingClusterStatuses[i].UnManagedLabels) > 0 {
+// hasUnManagedLabels returns true if any cluster in statuses has label conflicts.
+func hasUnManagedLabels(statuses []libsveltosv1beta1.MachingClusterStatus) bool {
+	for i := range statuses {
+		if len(statuses[i].UnManagedLabels) > 0 {
 			return true
 		}
 	}
-
 	return false
 }

--- a/controllers/classifier_controller_test.go
+++ b/controllers/classifier_controller_test.go
@@ -118,21 +118,24 @@ var _ = Describe("Classifier: Reconciler", func() {
 		Expect(c.Get(context.TODO(), classifierName, currentClassifier)).To(Succeed())
 		Expect(c.Delete(context.TODO(), currentClassifier)).To(Succeed())
 
-		Expect(c.Get(context.TODO(), classifierName, currentClassifier)).To(Succeed())
-		currentClassifier.Status.ClusterInfo = []libsveltosv1beta1.ClusterInfo{
-			{
-				Cluster: corev1.ObjectReference{
-					Namespace:  cluster.Namespace,
-					Name:       cluster.Name,
-					APIVersion: cluster.APIVersion,
-					Kind:       cluster.Kind,
-				},
-				Status: libsveltosv1beta1.SveltosStatusProvisioned,
-				Hash:   []byte(randomString()),
+		// Create a ClassifierReport for the cluster so undeployClassifier sees it and queues removal.
+		clusterType := libsveltosv1beta1.ClusterTypeCapi
+		reportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, cluster.Name, &clusterType)
+		classifierReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Name:      reportName,
+				Labels: libsveltosv1beta1.GetClassifierReportLabels(
+					classifier.Name, cluster.Name, &clusterType),
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: cluster.Namespace,
+				ClusterName:      cluster.Name,
+				ClusterType:      clusterType,
+				ClassifierName:   classifier.Name,
 			},
 		}
-
-		Expect(c.Status().Update(context.TODO(), currentClassifier)).To(Succeed())
+		Expect(c.Create(context.TODO(), classifierReport)).To(Succeed())
 
 		dep := fakedeployer.GetClient(context.TODO(),
 			logger, testEnv.Client)
@@ -148,8 +151,8 @@ var _ = Describe("Classifier: Reconciler", func() {
 			Logger:        logger,
 		}
 
-		// Because Classifier is currently deployed in a Cluster (Status.ClusterInfo is set
-		// indicating that) Reconcile won't be removed Finalizer
+		// Because a ClassifierReport exists for the cluster, undeployClassifier queues
+		// a removal job and returns an error, so the finalizer is kept.
 		_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{
 			NamespacedName: classifierName,
 		})
@@ -159,13 +162,11 @@ var _ = Describe("Classifier: Reconciler", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(controllerutil.ContainsFinalizer(currentClassifier, libsveltosv1beta1.ClassifierFinalizer)).To(BeTrue())
 
-		Expect(c.Get(context.TODO(), classifierName, currentClassifier)).To(Succeed())
+		// Delete the ClassifierReport to simulate that the cluster has been fully undeployed.
+		Expect(c.Delete(context.TODO(), classifierReport)).To(Succeed())
 
-		currentClassifier.Status.ClusterInfo = []libsveltosv1beta1.ClusterInfo{}
-		Expect(c.Status().Update(context.TODO(), currentClassifier)).To(Succeed())
-
-		// Because Classifier is currently deployed nowhere (Status.ClusterInfo is set
-		// indicating that) Reconcile will be removed Finalizer
+		// With no ClassifierReports remaining, undeployClassifier returns nil and
+		// reconcileDelete removes the finalizer, deleting the Classifier.
 		_, err = reconciler.Reconcile(context.TODO(), ctrl.Request{
 			NamespacedName: classifierName,
 		})
@@ -193,11 +194,31 @@ var _ = Describe("Classifier: Reconciler", func() {
 			Kind:       clusterv1.ClusterKind,
 		}] = true
 
+		// Create a ClassifierReport with the name the controller will look up when persisting
+		// label-management status, so we can verify ClassifierReport.Status is updated.
+		capiClusterType := libsveltosv1beta1.ClusterTypeCapi
+		persistedReportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, clusterName, &capiClusterType)
+		persistedReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      persistedReportName,
+				Labels: libsveltosv1beta1.GetClassifierReportLabels(
+					classifier.Name, clusterName, &capiClusterType),
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: clusterNamespace,
+				ClusterName:      clusterName,
+				ClusterType:      capiClusterType,
+				ClassifierName:   classifier.Name,
+			},
+		}
+
 		initObjects := []client.Object{
 			classifier,
 			classifierReport0,
 			classifierReport1,
 			classifierReport2,
+			persistedReport,
 		}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
@@ -220,13 +241,21 @@ var _ = Describe("Classifier: Reconciler", func() {
 		})
 		Expect(err).To(BeNil())
 
-		Expect(controllers.UpdateMatchingClustersAndRegistrations(reconciler, context.TODO(), classifierScope, matchingClusters,
-			logger)).To(Succeed())
+		statuses, err := controllers.UpdateMatchingClustersAndRegistrations(reconciler, context.TODO(), classifierScope, matchingClusters,
+			logger)
+		Expect(err).To(BeNil())
 
-		Expect(classifier.Status.MachingClusterStatuses).ToNot(BeNil())
-		Expect(len(classifier.Status.MachingClusterStatuses)).To(Equal(1))
-		Expect(classifier.Status.MachingClusterStatuses[0].ManagedLabels).ToNot(BeNil())
-		Expect(len(classifier.Status.MachingClusterStatuses[0].ManagedLabels)).To(Equal(len(classifier.Spec.ClassifierLabels)))
+		Expect(statuses).ToNot(BeNil())
+		Expect(len(statuses)).To(Equal(1))
+		Expect(statuses[0].ManagedLabels).ToNot(BeNil())
+		Expect(len(statuses[0].ManagedLabels)).To(Equal(len(classifier.Spec.ClassifierLabels)))
+
+		// Verify label-management data was persisted into ClassifierReport.Status.
+		updatedReport := &libsveltosv1beta1.ClassifierReport{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: persistedReportName},
+			updatedReport)).To(Succeed())
+		Expect(updatedReport.Status.ManagedLabels).To(HaveLen(len(classifier.Spec.ClassifierLabels)))
 	})
 
 	It("updateMatchingClustersAndRegistrations updates Classifier Status with detected misconfigurations", func() {
@@ -254,11 +283,31 @@ var _ = Describe("Classifier: Reconciler", func() {
 		classifierReport1 := getClassifierReport(classifier1.Name, clusterNamespace, clusterName)
 		classifierReport1.Spec.Match = true
 
+		// Create a ClassifierReport with the name the controller will look up when persisting
+		// label-management status, so we can verify ClassifierReport.Status is updated.
+		capiClusterType := libsveltosv1beta1.ClusterTypeCapi
+		persistedReportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, clusterName, &capiClusterType)
+		persistedReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      persistedReportName,
+				Labels: libsveltosv1beta1.GetClassifierReportLabels(
+					classifier.Name, clusterName, &capiClusterType),
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: clusterNamespace,
+				ClusterName:      clusterName,
+				ClusterType:      capiClusterType,
+				ClassifierName:   classifier.Name,
+			},
+		}
+
 		initObjects := []client.Object{
 			classifier,
 			classifier1,
 			classifierReport0,
 			classifierReport1,
+			persistedReport,
 		}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
@@ -289,17 +338,26 @@ var _ = Describe("Classifier: Reconciler", func() {
 		})
 		Expect(err).To(BeNil())
 
-		Expect(controllers.UpdateMatchingClustersAndRegistrations(reconciler, context.TODO(), classifierScope, matchingClusters,
-			logger)).To(Succeed())
+		statuses, err := controllers.UpdateMatchingClustersAndRegistrations(reconciler, context.TODO(), classifierScope, matchingClusters,
+			logger)
+		Expect(err).To(BeNil())
 
-		Expect(classifier.Status.MachingClusterStatuses).ToNot(BeNil())
-		Expect(len(classifier.Status.MachingClusterStatuses)).To(Equal(1))
-		Expect(classifier.Status.MachingClusterStatuses[0].ClusterRef.Namespace).To(Equal(clusterNamespace))
-		Expect(classifier.Status.MachingClusterStatuses[0].ClusterRef.Name).To(Equal(clusterName))
-		Expect(classifier.Status.MachingClusterStatuses[0].ClusterRef.APIVersion).To(Equal(clusterv1.GroupVersion.String()))
-		Expect(classifier.Status.MachingClusterStatuses[0].ClusterRef.Kind).To(Equal(clusterKind))
-		Expect(len(classifier.Status.MachingClusterStatuses[0].ManagedLabels)).To(BeZero())
-		Expect(len(classifier.Status.MachingClusterStatuses[0].UnManagedLabels)).To(Equal(len(classifier.Spec.ClassifierLabels)))
+		Expect(statuses).ToNot(BeNil())
+		Expect(len(statuses)).To(Equal(1))
+		Expect(statuses[0].ClusterRef.Namespace).To(Equal(clusterNamespace))
+		Expect(statuses[0].ClusterRef.Name).To(Equal(clusterName))
+		Expect(statuses[0].ClusterRef.APIVersion).To(Equal(clusterv1.GroupVersion.String()))
+		Expect(statuses[0].ClusterRef.Kind).To(Equal(clusterKind))
+		Expect(len(statuses[0].ManagedLabels)).To(BeZero())
+		Expect(len(statuses[0].UnManagedLabels)).To(Equal(len(classifier.Spec.ClassifierLabels)))
+
+		// Verify unmanaged label conflicts were persisted into ClassifierReport.Status.
+		updatedReport := &libsveltosv1beta1.ClassifierReport{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: persistedReportName},
+			updatedReport)).To(Succeed())
+		Expect(updatedReport.Status.ManagedLabels).To(BeEmpty())
+		Expect(updatedReport.Status.UnManagedLabels).To(HaveLen(len(classifier.Spec.ClassifierLabels)))
 	})
 
 	It("updateLabelsOnMatchingClusters updates CAPI Cluster labels", func() {
@@ -318,7 +376,7 @@ var _ = Describe("Classifier: Reconciler", func() {
 			managedLabels = append(managedLabels, classifier.Spec.ClassifierLabels[i].Key)
 		}
 
-		classifier.Status.MachingClusterStatuses = []libsveltosv1beta1.MachingClusterStatus{
+		matchingStatuses := []libsveltosv1beta1.MachingClusterStatus{
 			{
 				ClusterRef: corev1.ObjectReference{
 					Namespace:  cluster.Namespace,
@@ -365,7 +423,7 @@ var _ = Describe("Classifier: Reconciler", func() {
 			logger)).To(Succeed())
 
 		Expect(controllers.UpdateLabelsOnMatchingClusters(reconciler, context.TODO(), classifierScope,
-			logger)).To(Succeed())
+			matchingStatuses, logger)).To(Succeed())
 
 		currentCluster := &clusterv1.Cluster{}
 		Expect(c.Get(context.TODO(),
@@ -390,20 +448,27 @@ var _ = Describe("Classifier: Reconciler", func() {
 		classifier.Spec.ClassifierLabels = []libsveltosv1beta1.ClassifierLabel{
 			{Key: label, Value: randomString()},
 		}
-		classifier.Status.MachingClusterStatuses = []libsveltosv1beta1.MachingClusterStatus{
-			{
-				ClusterRef: corev1.ObjectReference{
-					Namespace:  clusterNamespace,
-					Name:       clusterName,
-					Kind:       clusterKind,
-					APIVersion: clusterv1.GroupVersion.String(),
-				},
-				ManagedLabels: []string{label},
+		// Create a ClassifierReport for the cluster so removeAllRegistrations finds it.
+		clusterType := libsveltosv1beta1.ClusterTypeCapi
+		reportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, clusterName, &clusterType)
+		classifierReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      reportName,
+				Labels: libsveltosv1beta1.GetClassifierReportLabels(
+					classifier.Name, clusterName, &clusterType),
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: clusterNamespace,
+				ClusterName:      clusterName,
+				ClusterType:      clusterType,
+				ClassifierName:   classifier.Name,
 			},
 		}
 
 		initObjects := []client.Object{
 			classifier,
+			classifierReport,
 		}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
@@ -464,24 +529,38 @@ var _ = Describe("Classifier: Reconciler", func() {
 			Name:       clusterName,
 		}
 
-		classifier.Status.MachingClusterStatuses = []libsveltosv1beta1.MachingClusterStatus{
-			{
-				ClusterRef: corev1.ObjectReference{
-					Namespace:  clusterNamespace,
-					Name:       clusterName,
-					Kind:       clusterKind,
-					APIVersion: clusterv1.GroupVersion.String(),
-				},
-				ManagedLabels: []string{labelKey},
+		// Create a ClassifierReport pre-populated with ManagedLabels so we can verify
+		// that cleanUpNonMatchingClusters clears ClassifierReport.Status after label removal.
+		sveltosClusterType := libsveltosv1beta1.ClusterTypeSveltos
+		reportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, clusterName, &sveltosClusterType)
+		classifierReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      reportName,
+				Labels: libsveltosv1beta1.GetClassifierReportLabels(
+					classifier.Name, clusterName, &sveltosClusterType),
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: clusterNamespace,
+				ClusterName:      clusterName,
+				ClusterType:      sveltosClusterType,
+				ClassifierName:   classifier.Name,
 			},
 		}
 
 		initObjects := []client.Object{
-			classifier, cluster,
+			classifier, cluster, classifierReport,
 		}
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
 			WithObjects(initObjects...).Build()
+
+		// Seed ManagedLabels into the ClassifierReport.Status to simulate a previous reconcile.
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: reportName}, classifierReport)).To(Succeed())
+		patchBase := classifierReport.DeepCopy()
+		classifierReport.Status.ManagedLabels = []string{labelKey}
+		Expect(c.Status().Patch(context.TODO(), classifierReport, client.MergeFrom(patchBase))).To(Succeed())
 
 		reconciler := &controllers.ClassifierReconciler{
 			Client:        c,
@@ -509,6 +588,13 @@ var _ = Describe("Classifier: Reconciler", func() {
 		// Register classifier as managing labels on cluster
 		manager.RegisterClassifierForLabels(classifier, clusterNamespace, clusterName, libsveltosv1beta1.ClusterTypeSveltos)
 
+		// Re-seed ManagedLabels (first call cleared them; second call should clear them again after removal).
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: reportName}, classifierReport)).To(Succeed())
+		patchBase = classifierReport.DeepCopy()
+		classifierReport.Status.ManagedLabels = []string{labelKey}
+		Expect(c.Status().Patch(context.TODO(), classifierReport, client.MergeFrom(patchBase))).To(Succeed())
+
 		err = controllers.CleanUpNonMatchingClusters(reconciler, context.TODO(), classifier, currentMatches, oldMatches, logger)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -516,6 +602,12 @@ var _ = Describe("Classifier: Reconciler", func() {
 		err = c.Get(context.TODO(), client.ObjectKey{Name: clusterRef.Name, Namespace: clusterRef.Namespace}, currentCluster)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(currentCluster.Labels).ToNot(HaveKey(labelKey))
+
+		// Verify ClassifierReport.Status.ManagedLabels was cleared after label removal.
+		updatedReport := &libsveltosv1beta1.ClassifierReport{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterNamespace, Name: reportName}, updatedReport)).To(Succeed())
+		Expect(updatedReport.Status.ManagedLabels).To(BeEmpty())
 	})
 
 	It("classifyLabels divides labels in managed and unmanaged", func() {

--- a/controllers/classifier_deployer.go
+++ b/controllers/classifier_deployer.go
@@ -120,55 +120,55 @@ func getSveltosAgentNamespace(sveltosNamespace string) string {
 func (r *ClassifierReconciler) deployClassifier(ctx context.Context, classifierScope *scope.ClassifierScope,
 	f feature, logger logr.Logger) error {
 
-	classifier := classifierScope.Classifier
-
-	logger = logger.WithValues("classifier", classifier.Name)
+	logger = logger.WithValues("classifier", classifierScope.Classifier.Name)
 	logger.V(logs.LogDebug).Info("request to deploy")
+
+	reports, err := listClassifierReportsForClassifier(ctx, r.Client, classifierScope.Classifier.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list ClassifierReports: %w", err)
+	}
 
 	var errorSeen error
 	allProcessed := true
 
-	for i := range classifier.Status.ClusterInfo {
-		c := &classifier.Status.ClusterInfo[i]
+	for i := range reports {
+		report := &reports[i]
+		if report.Spec.ClusterNamespace == "" {
+			continue
+		}
+		// Skip clusters whose removal has already completed.
+		if report.Status.DeploymentStatus != nil &&
+			*report.Status.DeploymentStatus == libsveltosv1beta1.SveltosStatusRemoved {
 
+			continue
+		}
+
+		cluster := getClusterRefFromClassifierReport(report)
 		l := logger.WithValues("cluster", fmt.Sprintf("%s:%s/%s",
-			c.Cluster.Kind, c.Cluster.Namespace, c.Cluster.Name))
+			cluster.Kind, cluster.Namespace, cluster.Name))
 
-		clusterInfo, err := r.processClassifier(ctx, classifierScope, r.ControlPlaneEndpoint, &c.Cluster, f, l)
+		clusterInfo, err := r.processClassifier(ctx, classifierScope, r.ControlPlaneEndpoint, cluster, f, l)
 		if err != nil {
 			errorSeen = err
 		}
 		if clusterInfo != nil {
-			classifier.Status.ClusterInfo[i] = *clusterInfo
+			if updateErr := updateClassifierReportDeploymentStatus(ctx, r.Client,
+				classifierScope.Classifier.Name, cluster, clusterInfo); updateErr != nil {
+				l.V(logs.LogInfo).Error(updateErr, "failed to update ClassifierReport deployment status")
+				errorSeen = updateErr
+			}
 			if clusterInfo.Status != libsveltosv1beta1.SveltosStatusProvisioned {
 				allProcessed = false
 			}
 		}
 	}
 
-	// Filter out entries with Statuslibsveltosv1beta1.SveltosStatusRemoved
-	n := 0
-	for i := range classifier.Status.ClusterInfo {
-		if classifier.Status.ClusterInfo[i].Status != libsveltosv1beta1.SveltosStatusRemoved {
-			classifier.Status.ClusterInfo[n] = classifier.Status.ClusterInfo[i]
-			n++
-		}
-	}
-	// Truncate the slice to the new length
-	classifier.Status.ClusterInfo = classifier.Status.ClusterInfo[:n]
-
-	// Update Classifier Status
-	logger.V(logs.LogDebug).Info("set clusterInfo")
-	classifierScope.SetClusterInfo(classifier.Status.ClusterInfo)
-
 	if errorSeen != nil {
 		return errorSeen
 	}
-
 	if !allProcessed {
 		return fmt.Errorf("request to deploy Classifier is still queued in one ore more clusters")
 	}
-
 	return nil
 }
 
@@ -176,20 +176,23 @@ func (r *ClassifierReconciler) undeployClassifier(ctx context.Context, classifie
 	f feature, logger logr.Logger) error {
 
 	classifier := classifierScope.Classifier
-
 	logger.V(logs.LogDebug).Info("request to undeploy")
 
-	clusters := make([]*corev1.ObjectReference, 0)
-	// Get list of clusters where Classifier needs to be removed
-	for i := range classifier.Status.ClusterInfo {
-		c := &classifier.Status.ClusterInfo[i].Cluster
+	reports, err := listClassifierReportsForClassifier(ctx, r.Client, classifier.Name)
+	if err != nil {
+		return fmt.Errorf("failed to list ClassifierReports: %w", err)
+	}
 
-		// Remove any queued entry to deploy/evaluate
+	clusters := make([]*corev1.ObjectReference, 0)
+	for i := range reports {
+		report := &reports[i]
+		if report.Spec.ClusterNamespace == "" {
+			continue
+		}
+		c := getClusterRefFromClassifierReport(report)
+
 		r.Deployer.CleanupEntries(c.Namespace, c.Name, classifier.Name, f.id, clusterproxy.GetClusterType(c), false)
 
-		// If deploying feature is in progress, wait for it to complete.
-		// Otherwise, if we cleanup feature while same feature is still being provisioned, if two workers process those request in
-		// parallel some resources might be left over.
 		if r.Deployer.IsInProgress(c.Namespace, c.Name, classifier.Name, f.id, clusterproxy.GetClusterType(c), false) {
 			logger.V(logs.LogDebug).Info("provisioning is in progress")
 			return fmt.Errorf("deploying %s still in progress. Wait before cleanup", f.id)
@@ -207,33 +210,27 @@ func (r *ClassifierReconciler) undeployClassifier(ctx context.Context, classifie
 		clusters = append(clusters, c)
 	}
 
-	clusterInfo := make([]libsveltosv1beta1.ClusterInfo, 0)
+	var failedCount int
 	for i := range clusters {
 		c := clusters[i]
 		err := r.removeClassifier(ctx, classifierScope, c, f, logger)
 		if err != nil {
 			failureMessage := err.Error()
-			clusterInfo = append(clusterInfo, libsveltosv1beta1.ClusterInfo{
-				Cluster:        *c,
-				Status:         libsveltosv1beta1.SveltosStatusRemoving,
-				FailureMessage: &failureMessage,
-			})
-		}
-	}
-
-	if len(clusterInfo) != 0 {
-		matchingClusterStatuses := make([]libsveltosv1beta1.MachingClusterStatus, len(clusterInfo))
-		for i := range clusterInfo {
-			matchingClusterStatuses[i] = libsveltosv1beta1.MachingClusterStatus{
-				ClusterRef: clusterInfo[i].Cluster,
+			if updateErr := updateClassifierReportDeploymentStatus(ctx, r.Client, classifier.Name, c,
+				&libsveltosv1beta1.ClusterInfo{
+					Cluster:        *c,
+					Status:         libsveltosv1beta1.SveltosStatusRemoving,
+					FailureMessage: &failureMessage,
+				}); updateErr != nil {
+				logger.V(logs.LogInfo).Error(updateErr, "failed to update ClassifierReport undeploy status")
 			}
+			failedCount++
 		}
-		classifierScope.SetMachingClusterStatuses(matchingClusterStatuses)
-		return fmt.Errorf("still in the process of removing Classifier from %d clusters",
-			len(clusterInfo))
 	}
 
-	classifierScope.SetClusterInfo(clusterInfo)
+	if failedCount > 0 {
+		return fmt.Errorf("still in the process of removing Classifier from %d clusters", failedCount)
+	}
 
 	return nil
 }
@@ -791,23 +788,20 @@ func (r *ClassifierReconciler) convertResultStatus(result deployer.Result) *libs
 	return nil
 }
 
-// getClassifierInClusterHashAndStatus returns the hash of the Classifier that was deployed in a given
-// Cluster (if ever deployed)
-func (r *ClassifierReconciler) getClassifierInClusterHashAndStatus(classifier *libsveltosv1beta1.Classifier,
-	cluster *corev1.ObjectReference) ([]byte, *libsveltosv1beta1.SveltosFeatureStatus) {
+// getClassifierInClusterHashAndStatus returns the hash and deployment status last recorded
+// for the Classifier in the given cluster by reading the ClassifierReport.Status.
+func (r *ClassifierReconciler) getClassifierInClusterHashAndStatus(ctx context.Context,
+	classifierName string, cluster *corev1.ObjectReference,
+) ([]byte, *libsveltosv1beta1.SveltosFeatureStatus, error) {
 
-	for i := range classifier.Status.ClusterInfo {
-		cInfo := &classifier.Status.ClusterInfo[i]
-		if cInfo.Cluster.Namespace == cluster.Namespace &&
-			cInfo.Cluster.Name == cluster.Name &&
-			cInfo.Cluster.APIVersion == cluster.APIVersion &&
-			cInfo.Cluster.Kind == cluster.Kind {
-
-			return cInfo.Hash, &cInfo.Status
+	report, err := getClassifierReportForCluster(ctx, r.Client, classifierName, cluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil, nil
 		}
+		return nil, nil, err
 	}
-
-	return nil, nil
+	return report.Status.Hash, report.Status.DeploymentStatus, nil
 }
 
 // isPaused returns true if Sveltos/CAPI Cluster is paused or ClusterSummary has paused annotation.
@@ -1029,7 +1023,12 @@ func (r *ClassifierReconciler) processClassifier(ctx context.Context, classifier
 	}
 
 	// Get the Classifier hash when Classifier was last deployed in this cluster (if ever)
-	hash, _ := r.getClassifierInClusterHashAndStatus(classifier, cluster)
+	hash, _, err := r.getClassifierInClusterHashAndStatus(ctx, classifier.Name, cluster)
+	if err != nil {
+		failureMessage := err.Error()
+		clusterInfo.FailureMessage = &failureMessage
+		return clusterInfo, err
+	}
 	isConfigSame := reflect.DeepEqual(hash, currentHash)
 	if !isConfigSame {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("Classifier has changed. Current hash %x. Previous hash %x",
@@ -1061,7 +1060,12 @@ func (r *ClassifierReconciler) proceedProcessingClassifier(ctx context.Context, 
 		Status:         libsveltosv1beta1.SveltosStatusProvisioning,
 	}
 
-	_, currentStatus := r.getClassifierInClusterHashAndStatus(classifier, cluster)
+	_, currentStatus, err := r.getClassifierInClusterHashAndStatus(ctx, classifier.Name, cluster)
+	if err != nil {
+		failureMessage := err.Error()
+		clusterInfo.FailureMessage = &failureMessage
+		return clusterInfo, err
+	}
 
 	var deployerStatus *libsveltosv1beta1.SveltosFeatureStatus
 	var result deployer.Result
@@ -1099,6 +1103,13 @@ func (r *ClassifierReconciler) proceedProcessingClassifier(ctx context.Context, 
 		logger.V(logs.LogDebug).Info("already deployed")
 		clusterInfo.Status = libsveltosv1beta1.SveltosStatusProvisioned
 		clusterInfo.FailureMessage = stringPtr("")
+	} else if isPullMode && isConfigSame {
+		// In pull mode the deployer result may have already been consumed on a prior reconcile
+		// while the agent is still processing the staged ConfigurationGroup. Delegate to the
+		// pull-mode path, which checks whether a ConfigurationGroup already exists and waits
+		// rather than queuing a new deploy that would call DiscardStagedResourcesForDeployment
+		// and wipe the bundle the agent is currently working on.
+		return r.proceedDeployingClassifierInPullMode(ctx, classifier, cluster, f, isConfigSame, currentHash, logger)
 	} else {
 		logger.V(logs.LogDebug).Info("no result is available. queue job and mark status as provisioning")
 		clusterInfo.Status = libsveltosv1beta1.SveltosStatusProvisioning
@@ -1186,6 +1197,12 @@ func (r *ClassifierReconciler) proceedDeployingClassifierInPullMode(ctx context.
 				clusterInfo.FailureMessage = &failureMessage
 				return clusterInfo, err
 			}
+			// Clear the deployer's cached result so that subsequent reconciles use the
+			// "already deployed" path (isConfigSame && currentStatus == Provisioned) rather
+			// than re-entering this function and re-queuing because the ConfigurationBundle
+			// is now gone.
+			r.Deployer.CleanupEntries(cluster.Namespace, cluster.Name, classifier.Name, f.id,
+				clusterproxy.GetClusterType(cluster), false)
 			clusterInfo.Status = libsveltosv1beta1.SveltosStatusProvisioned
 			return clusterInfo, nil
 		case libsveltosv1beta1.FeatureStatusProvisioning:
@@ -1202,6 +1219,13 @@ func (r *ClassifierReconciler) proceedDeployingClassifierInPullMode(ctx context.
 		}
 	} else {
 		clusterInfo.Status = libsveltosv1beta1.SveltosStatusProvisioning
+		if isConfigSame {
+			// The ConfigurationBundle exists with the correct hash; the agent simply hasn't
+			// reported a status yet. Wait — do NOT re-queue a new deploy job, which would
+			// call DiscardStagedResourcesForDeployment and wipe the bundle the agent is
+			// currently working on, causing an infinite treadmill.
+			return clusterInfo, nil
+		}
 	}
 
 	// Getting here means either agent failed to deploy feature or configuration has changed.

--- a/controllers/classifier_deployer_test.go
+++ b/controllers/classifier_deployer_test.go
@@ -322,28 +322,43 @@ var _ = Describe("Classifier Deployer", func() {
 		Expect(waitForObject(context.TODO(), testEnv.Client, classifier)).To(Succeed())
 
 		hash := controllers.ClassifierHash(classifier)
-		Expect(testEnv.Get(context.TODO(), types.NamespacedName{Name: classifier.Name}, classifier)).To(Succeed())
-		classifier.Status = libsveltosv1beta1.ClassifierStatus{
-			ClusterInfo: []libsveltosv1beta1.ClusterInfo{
-				{
-					Cluster: corev1.ObjectReference{
-						Namespace: cluster.Namespace, Name: cluster.Name,
-						APIVersion: clusterv1.GroupVersion.String(), Kind: clusterKind,
-					},
-					Status: libsveltosv1beta1.SveltosStatusProvisioned,
-					Hash:   hash,
-				},
+
+		// Create a ClassifierReport for the cluster carrying the current hash and provisioned status
+		// so that processClassifier detects the configuration is already deployed.
+		clusterType := libsveltosv1beta1.ClusterTypeCapi
+		reportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, cluster.Name, &clusterType)
+		provisioned := libsveltosv1beta1.SveltosStatusProvisioned
+		classifierReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Name:      reportName,
+				Labels: libsveltosv1beta1.GetClassifierReportLabels(
+					classifier.Name, cluster.Name, &clusterType),
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: cluster.Namespace,
+				ClusterName:      cluster.Name,
+				ClusterType:      clusterType,
+				ClassifierName:   classifier.Name,
 			},
 		}
-		Expect(testEnv.Status().Update(context.TODO(), classifier)).To(Succeed())
+		Expect(testEnv.Create(context.TODO(), classifierReport)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, classifierReport)).To(Succeed())
+
+		Expect(testEnv.Get(context.TODO(),
+			types.NamespacedName{Namespace: cluster.Namespace, Name: reportName}, classifierReport)).To(Succeed())
+		classifierReport.Status.Hash = hash
+		classifierReport.Status.DeploymentStatus = &provisioned
+		Expect(testEnv.Status().Update(context.TODO(), classifierReport)).To(Succeed())
 
 		Eventually(func() bool {
-			err := testEnv.Get(context.TODO(), types.NamespacedName{Name: classifier.Name}, classifier)
-			if err != nil {
+			r := &libsveltosv1beta1.ClassifierReport{}
+			if err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: cluster.Namespace, Name: reportName}, r); err != nil {
 				return false
 			}
-			return len(classifier.Status.ClusterInfo) == 1 &&
-				classifier.Status.ClusterInfo[0].Status == libsveltosv1beta1.SveltosStatusProvisioned
+			return r.Status.DeploymentStatus != nil &&
+				*r.Status.DeploymentStatus == libsveltosv1beta1.SveltosStatusProvisioned
 		}, timeout, pollingInterval).Should(BeTrue())
 
 		classifierScope := getClassifierScope(testEnv.Client, logger, classifier)
@@ -369,29 +384,6 @@ var _ = Describe("Classifier Deployer", func() {
 
 		Expect(waitForObject(context.TODO(), testEnv.Client, classifier)).To(Succeed())
 
-		currentClassifier := &libsveltosv1beta1.Classifier{}
-		Expect(testEnv.Get(context.TODO(), types.NamespacedName{Name: classifier.Name},
-			currentClassifier)).To(Succeed())
-		currentClassifier.Status.ClusterInfo = []libsveltosv1beta1.ClusterInfo{
-			{
-				Cluster: corev1.ObjectReference{
-					Namespace: cluster.Namespace, Name: cluster.Name,
-					APIVersion: clusterv1.GroupVersion.String(), Kind: clusterKind,
-				},
-				Status: libsveltosv1beta1.SveltosStatusProvisioned,
-				Hash:   []byte(randomString()),
-			},
-		}
-
-		Expect(testEnv.Status().Update(context.TODO(), currentClassifier)).To(Succeed())
-		// Eventual loop so testEnv Cache is synced
-		Eventually(func() bool {
-			currentClassifier := &libsveltosv1beta1.Classifier{}
-			err := testEnv.Get(context.TODO(), types.NamespacedName{Name: classifier.Name},
-				currentClassifier)
-			return err == nil && len(currentClassifier.Status.ClusterInfo) == 1
-		}, timeout, pollingInterval).Should(BeTrue())
-
 		f := controllers.GetHandlersForFeature(libsveltosv1beta1.FeatureClassifier)
 		err := controllers.RemoveClassifier(classifierReconciler, context.TODO(), classifierScope,
 			getClusterRef(cluster), f, logger)
@@ -413,29 +405,6 @@ var _ = Describe("Classifier Deployer", func() {
 		Expect(testEnv.Create(context.TODO(), classifier)).To(Succeed())
 
 		Expect(waitForObject(context.TODO(), testEnv.Client, classifier)).To(Succeed())
-
-		currentClassifier := &libsveltosv1beta1.Classifier{}
-		Expect(testEnv.Get(context.TODO(), types.NamespacedName{Name: classifier.Name},
-			currentClassifier)).To(Succeed())
-		currentClassifier.Status.ClusterInfo = []libsveltosv1beta1.ClusterInfo{
-			{
-				Cluster: corev1.ObjectReference{
-					Namespace: cluster.Namespace, Name: cluster.Name,
-					APIVersion: clusterv1.GroupVersion.String(), Kind: clusterKind,
-				},
-				Status: libsveltosv1beta1.SveltosStatusProvisioned,
-				Hash:   []byte(randomString()),
-			},
-		}
-
-		Expect(testEnv.Status().Update(context.TODO(), currentClassifier)).To(Succeed())
-		// Eventual loop so testEnv Cache is synced
-		Eventually(func() bool {
-			currentClassifier := &libsveltosv1beta1.Classifier{}
-			err := testEnv.Get(context.TODO(), types.NamespacedName{Name: classifier.Name},
-				currentClassifier)
-			return err == nil && len(currentClassifier.Status.ClusterInfo) == 1
-		}, timeout, pollingInterval).Should(BeTrue())
 
 		err := controllers.UndeployClassifierFromCluster(context.TODO(), testEnv, cluster.Namespace, cluster.Name,
 			classifier.Name, libsveltosv1beta1.FeatureClassifier, libsveltosv1beta1.ClusterTypeCapi,
@@ -464,27 +433,29 @@ var _ = Describe("Classifier Deployer", func() {
 
 		Expect(waitForObject(context.TODO(), testEnv.Client, classifier)).To(Succeed())
 
+		// Create a ClassifierReport for the cluster so undeployClassifier finds it and queues removal.
+		clusterType := libsveltosv1beta1.ClusterTypeCapi
+		reportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, cluster.Name, &clusterType)
+		classifierReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Name:      reportName,
+				Labels: libsveltosv1beta1.GetClassifierReportLabels(
+					classifier.Name, cluster.Name, &clusterType),
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: cluster.Namespace,
+				ClusterName:      cluster.Name,
+				ClusterType:      clusterType,
+				ClassifierName:   classifier.Name,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), classifierReport)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, classifierReport)).To(Succeed())
+
 		currentClassifier := &libsveltosv1beta1.Classifier{}
 		Expect(testEnv.Get(context.TODO(), types.NamespacedName{Name: classifier.Name},
 			currentClassifier)).To(Succeed())
-		currentClassifier.Status.ClusterInfo = []libsveltosv1beta1.ClusterInfo{
-			{
-				Cluster: corev1.ObjectReference{
-					Namespace: cluster.Namespace, Name: cluster.Name,
-					APIVersion: clusterv1.GroupVersion.String(), Kind: clusterKind,
-				},
-				Status: libsveltosv1beta1.SveltosStatusProvisioned,
-				Hash:   []byte(randomString()),
-			},
-		}
-
-		Expect(testEnv.Status().Update(context.TODO(), currentClassifier)).To(Succeed())
-		// Eventual loop so testEnv Cache is synced
-		Eventually(func() bool {
-			err := testEnv.Get(context.TODO(), types.NamespacedName{Name: classifier.Name},
-				currentClassifier)
-			return err == nil && len(currentClassifier.Status.ClusterInfo) == 1
-		}, timeout, pollingInterval).Should(BeTrue())
 
 		classifierScope := getClassifierScope(testEnv.Client, logger, currentClassifier)
 

--- a/controllers/keymanager/keymanager.go
+++ b/controllers/keymanager/keymanager.go
@@ -354,45 +354,42 @@ func isClassifierAlreadyRegistered(classifiers []string, classifierKey string) b
 
 // rebuildRegistrations rebuilds internal structures to identify Classifiers managing
 // labels and Classifiers currently just registered but not managing.
-// Relies completely on Classifier.Status
+// Reads from ClassifierReport.Status (the authoritative post-migration location).
 func (m *instance) rebuildRegistrations(ctx context.Context, c client.Client) error {
 	// Lock here
 	m.chartMux.Lock()
 	defer m.chartMux.Unlock()
 
-	classifierList := &libsveltosv1beta1.ClassifierList{}
-	err := c.List(ctx, classifierList)
-	if err != nil {
+	reportList := &libsveltosv1beta1.ClassifierReportList{}
+	if err := c.List(ctx, reportList); err != nil {
 		return err
 	}
 
-	for i := range classifierList.Items {
-		cs := &classifierList.Items[i]
-		m.addManagers(cs)
+	// First pass: register primary managers (ManagedLabels).
+	for i := range reportList.Items {
+		report := &reportList.Items[i]
+		if report.Spec.ClusterNamespace == "" || len(report.Status.ManagedLabels) == 0 {
+			continue
+		}
+		clusterKey := m.getClusterKey(report.Spec.ClusterNamespace, report.Spec.ClusterName, report.Spec.ClusterType)
+		classifierKey := m.getClassifierKey(report.Spec.ClassifierName)
+		m.addManagedLabelsInCluster(classifierKey, clusterKey, report.Status.ManagedLabels)
 	}
 
-	for i := range classifierList.Items {
-		cs := &classifierList.Items[i]
-		m.addNonManagers(cs)
+	// Second pass: register non-managers (UnManagedLabels) so they appear in the list
+	// and can take over when the current manager is removed.
+	for i := range reportList.Items {
+		report := &reportList.Items[i]
+		if report.Spec.ClusterNamespace == "" || len(report.Status.UnManagedLabels) == 0 {
+			continue
+		}
+		clusterKey := m.getClusterKey(report.Spec.ClusterNamespace, report.Spec.ClusterName, report.Spec.ClusterType)
+		classifierKey := m.getClassifierKey(report.Spec.ClassifierName)
+		unManagedKeys := m.buildSliceOfUnManagedLabels(report.Status.UnManagedLabels)
+		m.addManagedLabelsInCluster(classifierKey, clusterKey, unManagedKeys)
 	}
 
 	return nil
-}
-
-// addManagers walks Classifier's status and registers it for each label currently managed
-func (m *instance) addManagers(classifier *libsveltosv1beta1.Classifier) {
-	classifierKey := m.getClassifierKey(classifier.Name)
-
-	for i := range classifier.Status.MachingClusterStatuses {
-		clusterStatus := &classifier.Status.MachingClusterStatuses[i]
-		clusterType := libsveltosv1beta1.ClusterTypeCapi
-		if clusterStatus.ClusterRef.APIVersion == libsveltosv1beta1.GroupVersion.String() {
-			clusterType = libsveltosv1beta1.ClusterTypeSveltos
-		}
-		clusterKey := m.getClusterKey(clusterStatus.ClusterRef.Namespace, clusterStatus.ClusterRef.Name, clusterType)
-
-		m.addManagedLabelsInCluster(classifierKey, clusterKey, clusterStatus.ManagedLabels)
-	}
 }
 
 func (m *instance) addManagedLabelsInCluster(classifierKey, clusterKey string, managedLabels []string) {
@@ -401,24 +398,6 @@ func (m *instance) addManagedLabelsInCluster(classifierKey, clusterKey string, m
 		m.addClusterEntry(clusterKey)
 		m.addLabelKeyEntry(clusterKey, labelKey)
 		m.addClassifierEntry(clusterKey, labelKey, classifierKey)
-	}
-}
-
-// addNonManagers walks Classifier's status and registers it for each labels currently not managed
-// (not managed because other Classifier is)
-func (m *instance) addNonManagers(classifier *libsveltosv1beta1.Classifier) {
-	classifierKey := m.getClassifierKey(classifier.Name)
-
-	for i := range classifier.Status.MachingClusterStatuses {
-		clusterStatus := &classifier.Status.MachingClusterStatuses[i]
-		clusterType := libsveltosv1beta1.ClusterTypeCapi
-		if clusterStatus.ClusterRef.APIVersion == libsveltosv1beta1.GroupVersion.String() {
-			clusterType = libsveltosv1beta1.ClusterTypeSveltos
-		}
-		clusterKey := m.getClusterKey(clusterStatus.ClusterRef.Namespace, clusterStatus.ClusterRef.Name, clusterType)
-
-		unManagedLabels := m.buildSliceOfUnManagedLabels(clusterStatus.UnManagedLabels)
-		m.addManagedLabelsInCluster(classifierKey, clusterKey, unManagedLabels)
 	}
 }
 

--- a/controllers/keymanager/keymanager_test.go
+++ b/controllers/keymanager/keymanager_test.go
@@ -23,7 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -237,38 +236,52 @@ var _ = Describe("Chart manager", func() {
 	It("rebuildRegistrations rebuilds label (keys) registrations", func() {
 		Expect(len(classifier.Spec.ClassifierLabels)).Should(BeNumerically(">=", 2))
 
-		// Mark classifier as manager for one release
-		classifier.Status = libsveltosv1beta1.ClassifierStatus{
-			MachingClusterStatuses: []libsveltosv1beta1.MachingClusterStatus{
-				{
-					ClusterRef: corev1.ObjectReference{Namespace: sveltosCluster.Namespace, Name: sveltosCluster.Name,
-						APIVersion: libsveltosv1beta1.GroupVersion.String(), Kind: libsveltosv1beta1.SveltosClusterKind},
-					ManagedLabels:   []string{classifier.Spec.ClassifierLabels[0].Key},
-					UnManagedLabels: []libsveltosv1beta1.UnManagedLabel{{Key: classifier.Spec.ClassifierLabels[1].Key}},
-				},
+		// Create ClassifierReport for classifier: manages ClassifierLabels[0], unmanaged ClassifierLabels[1]
+		classifierReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: sveltosCluster.Namespace,
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: sveltosCluster.Namespace,
+				ClusterName:      sveltosCluster.Name,
+				ClusterType:      libsveltosv1beta1.ClusterTypeSveltos,
+				ClassifierName:   classifier.Name,
+			},
+			Status: libsveltosv1beta1.ClassifierReportStatus{
+				ManagedLabels:   []string{classifier.Spec.ClassifierLabels[0].Key},
+				UnManagedLabels: []libsveltosv1beta1.UnManagedLabel{{Key: classifier.Spec.ClassifierLabels[1].Key}},
 			},
 		}
-		Expect(c.Status().Update(context.TODO(), classifier)).To(Succeed())
+		Expect(c.Create(context.TODO(), classifierReport)).To(Succeed())
 
-		// Mark tmpClassifier as manager for classifier.Spec.ClassifierLabels[1]
 		tmpClassifier := &libsveltosv1beta1.Classifier{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: classifier.Name + randomString(),
 			},
 			Spec: classifier.Spec,
-			Status: libsveltosv1beta1.ClassifierStatus{
-				MachingClusterStatuses: []libsveltosv1beta1.MachingClusterStatus{
-					{
-						ClusterRef: corev1.ObjectReference{Namespace: sveltosCluster.Namespace, Name: sveltosCluster.Name,
-							APIVersion: libsveltosv1beta1.GroupVersion.String(), Kind: libsveltosv1beta1.SveltosClusterKind},
-						ManagedLabels:   []string{classifier.Spec.ClassifierLabels[1].Key},
-						UnManagedLabels: []libsveltosv1beta1.UnManagedLabel{{Key: classifier.Spec.ClassifierLabels[0].Key}},
-					},
-				},
-			},
 		}
 		Expect(c.Create(context.TODO(), tmpClassifier)).To(Succeed())
 		defer removeSubscriptions(c, tmpClassifier, sveltosCluster.Namespace, sveltosCluster.Name, libsveltosv1beta1.ClusterTypeSveltos)
+
+		// Create ClassifierReport for tmpClassifier: manages ClassifierLabels[1], unmanaged ClassifierLabels[0]
+		tmpClassifierReport := &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: sveltosCluster.Namespace,
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: sveltosCluster.Namespace,
+				ClusterName:      sveltosCluster.Name,
+				ClusterType:      libsveltosv1beta1.ClusterTypeSveltos,
+				ClassifierName:   tmpClassifier.Name,
+			},
+			Status: libsveltosv1beta1.ClassifierReportStatus{
+				ManagedLabels:   []string{classifier.Spec.ClassifierLabels[1].Key},
+				UnManagedLabels: []libsveltosv1beta1.UnManagedLabel{{Key: classifier.Spec.ClassifierLabels[0].Key}},
+			},
+		}
+		Expect(c.Create(context.TODO(), tmpClassifierReport)).To(Succeed())
 
 		manager, err := keymanager.GetKeyManagerInstance(context.TODO(), c)
 		Expect(err).To(BeNil())

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -27,8 +27,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -227,6 +229,110 @@ func deplAssociatedClusterExist(ctx context.Context, c client.Client, depl *apps
 
 func stringPtr(s string) *string {
 	return &s
+}
+
+// listClassifierReportsForClassifier returns all ClassifierReports labeled for the given classifier.
+func listClassifierReportsForClassifier(ctx context.Context, c client.Client,
+	classifierName string) ([]libsveltosv1beta1.ClassifierReport, error) {
+
+	reportList := &libsveltosv1beta1.ClassifierReportList{}
+	if err := c.List(ctx, reportList, client.MatchingLabels{
+		libsveltosv1beta1.ClassifierlNameLabel: classifierName,
+	}); err != nil {
+		return nil, err
+	}
+	return reportList.Items, nil
+}
+
+// getClassifierReportForCluster returns the ClassifierReport for a (classifier, cluster) pair.
+func getClassifierReportForCluster(ctx context.Context, c client.Client,
+	classifierName string, cluster *corev1.ObjectReference) (*libsveltosv1beta1.ClassifierReport, error) {
+
+	clusterType := clusterproxy.GetClusterType(cluster)
+	reportName := libsveltosv1beta1.GetClassifierReportName(classifierName, cluster.Name, &clusterType)
+	report := &libsveltosv1beta1.ClassifierReport{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: reportName}, report); err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+// ensureClassifierReportForCluster creates a ClassifierReport for a cluster if one does not already exist.
+// The report is initialized with Match=false; the agent updates Spec.Match on its next reconcile.
+func ensureClassifierReportForCluster(ctx context.Context, c client.Client,
+	classifierName string, cluster *corev1.ObjectReference) error {
+
+	clusterType := clusterproxy.GetClusterType(cluster)
+	reportName := libsveltosv1beta1.GetClassifierReportName(classifierName, cluster.Name, &clusterType)
+
+	existing := &libsveltosv1beta1.ClassifierReport{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: reportName}, existing)
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	report := &libsveltosv1beta1.ClassifierReport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      reportName,
+			Labels:    libsveltosv1beta1.GetClassifierReportLabels(classifierName, cluster.Name, &clusterType),
+		},
+		Spec: libsveltosv1beta1.ClassifierReportSpec{
+			ClusterNamespace: cluster.Namespace,
+			ClusterName:      cluster.Name,
+			ClusterType:      clusterType,
+			ClassifierName:   classifierName,
+			Match:            false,
+		},
+	}
+	if createErr := c.Create(ctx, report); createErr != nil && !apierrors.IsAlreadyExists(createErr) {
+		return createErr
+	}
+	return nil
+}
+
+// updateClassifierReportDeploymentStatus patches ClassifierReport.Status with deployment tracking data
+// (hash, deployment status, failure message) from a processClassifier result.
+func updateClassifierReportDeploymentStatus(ctx context.Context, c client.Client,
+	classifierName string, cluster *corev1.ObjectReference,
+	clusterInfo *libsveltosv1beta1.ClusterInfo) error {
+
+	report, err := getClassifierReportForCluster(ctx, c, classifierName, cluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	patch := client.MergeFrom(report.DeepCopy())
+	report.Status.Hash = clusterInfo.Hash
+	report.Status.DeploymentStatus = &clusterInfo.Status
+	report.Status.FailureMessage = clusterInfo.FailureMessage
+	return c.Status().Patch(ctx, report, patch)
+}
+
+// updateClassifierReportLabelStatus patches ClassifierReport.Status with label management data.
+// Pass nil slices to clear the tracking when a cluster stops matching.
+func updateClassifierReportLabelStatus(ctx context.Context, c client.Client,
+	classifierName string, cluster *corev1.ObjectReference,
+	managed []string, unmanaged []libsveltosv1beta1.UnManagedLabel) error {
+
+	report, err := getClassifierReportForCluster(ctx, c, classifierName, cluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	patch := client.MergeFrom(report.DeepCopy())
+	report.Status.ManagedLabels = managed
+	report.Status.UnManagedLabels = unmanaged
+	return c.Status().Patch(ctx, report, patch)
 }
 
 func sortPatches(patches []libsveltosv1beta1.Patch) {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f
+	github.com/projectsveltos/libsveltos v1.10.1-0.20260601120418-b36ef8f72429
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	golang.org/x/text v0.37.0

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f h1:XrgpnRRH59AwSkSEIcKPUDpAME0Sl4sXLeEhDIaYQMU=
-github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f/go.mod h1:AzKBiyMTL3KSTLYMii5QdR3ieWyUKBHZCMFWIVCfm6A=
+github.com/projectsveltos/libsveltos v1.10.1-0.20260601120418-b36ef8f72429 h1:O9Bda6TNe+5nqStIkjiROiY38y7XiuWkfz60ClEn9vc=
+github.com/projectsveltos/libsveltos v1.10.1-0.20260601120418-b36ef8f72429/go.mod h1:AzKBiyMTL3KSTLYMii5QdR3ieWyUKBHZCMFWIVCfm6A=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/main.go
+++ b/main.go
@@ -102,13 +102,12 @@ func main() {
 	}
 
 	klog.InitFlags(nil)
+	ctrl.SetLogger(klog.Background())
 
 	initFlags(pflag.CommandLine)
 	pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
-
-	ctrl.SetLogger(klog.Background())
 
 	reportMode = controllers.ReportMode(tmpReportMode)
 
@@ -125,13 +124,13 @@ func main() {
 	}
 
 	sveltosNamespace := getSveltosNamespace()
+	configureGlobalState(mgr, sveltosNamespace)
 
-	controllers.SetManagementClusterAccess(mgr.GetConfig(), mgr.GetClient())
-	controllers.SetSveltosAgentConfigMap(sveltosAgentConfigMap)
-	controllers.SetSveltosApplierConfigMap(sveltosApplierConfigMap)
-	controllers.SetSveltosAgentRegistry(registry)
-	controllers.SetAgentInMgmtCluster(agentInMgmtCluster)
-	controllers.SetSveltosNamespace(sveltosNamespace)
+	if isInitContainer() {
+		setupLog.V(logs.LogInfo).Info("running migration")
+		runMigrateMode(scheme)
+		os.Exit(0)
+	}
 
 	setupLog.V(logs.LogInfo).Info(fmt.Sprintf("Running in managemnt cluster: %t", agentInMgmtCluster))
 
@@ -255,6 +254,39 @@ func setupChecks(mgr ctrl.Manager) {
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+}
+
+// isInitContainer returns true when the binary is running as the migration init container.
+// The init container sets IS_INITIALIZATION=true in its env to signal this mode.
+func isInitContainer() bool {
+	return os.Getenv("IS_INITIALIZATION") == "true"
+}
+
+// configureGlobalState sets all package-level state that controllers depend on.
+// Extracted to keep main() within the funlen limit.
+func configureGlobalState(mgr ctrl.Manager, sveltosNamespace string) {
+	controllers.SetManagementClusterAccess(mgr.GetConfig(), mgr.GetClient())
+	controllers.SetSveltosAgentConfigMap(sveltosAgentConfigMap)
+	controllers.SetSveltosApplierConfigMap(sveltosApplierConfigMap)
+	controllers.SetSveltosAgentRegistry(registry)
+	controllers.SetAgentInMgmtCluster(agentInMgmtCluster)
+	controllers.SetSveltosNamespace(sveltosNamespace)
+}
+
+// runMigrateMode runs the one-shot Classifier status migration and exits.
+// Extracted to keep main() within the funlen limit.
+func runMigrateMode(scheme *runtime.Scheme) {
+	restConfig := ctrl.GetConfigOrDie()
+	migrationClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "failed to create client for migration")
+		os.Exit(1)
+	}
+	if err := runMigration(context.Background(), migrationClient,
+		ctrl.Log.WithName("migrate")); err != nil {
+		setupLog.Error(err, "migration failed")
 		os.Exit(1)
 	}
 }

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -43,6 +43,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: docker.io/projectsveltos/classifier:main
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -73,7 +74,32 @@ spec:
             memory: 512Mi
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      initContainers:
+      - command:
+        - /manager
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: IS_INITIALIZATION
+          value: "true"
+        image: docker.io/projectsveltos/classifier:main
+        imagePullPolicy: IfNotPresent
+        name: migrate
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -43,6 +43,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: docker.io/projectsveltos/classifier:main
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -73,7 +74,32 @@ spec:
             memory: 512Mi
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      initContainers:
+      - command:
+        - /manager
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: IS_INITIALIZATION
+          value: "true"
+        image: docker.io/projectsveltos/classifier:main
+        imagePullPolicy: IfNotPresent
+        name: migrate
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -97,16 +97,17 @@ rules:
 - apiGroups:
   - lib.projectsveltos.io
   resources:
-  - classifiers/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - lib.projectsveltos.io
-  resources:
+  - classifierreports/status
   - classifiers/status
   verbs:
   - get
   - patch
+  - update
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - classifiers/finalizers
+  verbs:
   - update
 - apiGroups:
   - lib.projectsveltos.io
@@ -187,6 +188,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         image: docker.io/projectsveltos/classifier:main
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -217,7 +219,32 @@ spec:
             memory: 512Mi
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      initContainers:
+      - command:
+        - /manager
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: IS_INITIALIZATION
+          value: "true"
+        image: docker.io/projectsveltos/classifier:main
+        imagePullPolicy: IfNotPresent
+        name: migrate
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/migration.go
+++ b/migration.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// runMigration is a one-shot operation run as a Kubernetes init container
+// (via /manager --migrate) before the classifier controller starts.
+// It moves per-cluster state previously stored in Classifier.Status
+// (ClusterInfo and MachingClusterStatuses) into the Status subresource of the
+// corresponding ClassifierReport objects.
+//
+// A Classifier instance is skipped when both arrays are already empty, so the
+// operation is safe to re-run if the init container restarts.
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+// runMigration lists all Classifier instances and migrates any that still carry
+// per-cluster data in the deprecated ClusterInfo / MachingClusterStatuses fields.
+func runMigration(ctx context.Context, c client.Client, log logr.Logger) error {
+	classifierList := &libsveltosv1beta1.ClassifierList{}
+	if err := c.List(ctx, classifierList); err != nil {
+		return fmt.Errorf("listing Classifier instances: %w", err)
+	}
+
+	for i := range classifierList.Items {
+		classifier := &classifierList.Items[i]
+
+		//nolint:staticcheck // deprecated, migration only
+		if len(classifier.Status.ClusterInfo) == 0 && len(classifier.Status.MachingClusterStatuses) == 0 {
+			log.V(1).Info("skipping (already migrated or no data)", "classifier", classifier.Name)
+			continue
+		}
+
+		log.Info("migrating", "classifier", classifier.Name,
+			"clusterInfoCount", len(classifier.Status.ClusterInfo), //nolint:staticcheck // deprecated, migration only
+			"matchingCount", len(classifier.Status.MachingClusterStatuses)) //nolint:staticcheck // deprecated, migration only
+
+		if err := migrateOneClassifier(ctx, c, classifier); err != nil {
+			return fmt.Errorf("migrating classifier %s: %w", classifier.Name, err)
+		}
+
+		log.Info("migrated successfully", "classifier", classifier.Name)
+	}
+
+	log.Info("migration complete")
+	return nil
+}
+
+// migrateOneClassifier migrates one Classifier instance and clears the deprecated arrays.
+func migrateOneClassifier(ctx context.Context, c client.Client,
+	classifier *libsveltosv1beta1.Classifier) error {
+
+	type clusterData struct {
+		ref              corev1.ObjectReference
+		hash             []byte
+		deploymentStatus *libsveltosv1beta1.SveltosFeatureStatus
+		failureMessage   *string
+		managedLabels    []string
+		unmanagedLabels  []libsveltosv1beta1.UnManagedLabel
+	}
+
+	byCluster := make(map[string]*clusterData)
+
+	key := func(ref corev1.ObjectReference) string {
+		return fmt.Sprintf("%s/%s/%s", ref.Kind, ref.Namespace, ref.Name)
+	}
+
+	for i := range classifier.Status.ClusterInfo { //nolint:staticcheck // deprecated, migration only
+		ci := &classifier.Status.ClusterInfo[i] //nolint:staticcheck // deprecated, migration only
+		d := &clusterData{ref: ci.Cluster}
+		if len(ci.Hash) > 0 {
+			d.hash = ci.Hash
+		}
+		s := ci.Status
+		d.deploymentStatus = &s
+		d.failureMessage = ci.FailureMessage
+		byCluster[key(ci.Cluster)] = d
+	}
+
+	for i := range classifier.Status.MachingClusterStatuses { //nolint:staticcheck // deprecated, migration only
+		ms := &classifier.Status.MachingClusterStatuses[i] //nolint:staticcheck // deprecated, migration only
+		k := key(ms.ClusterRef)
+		d, ok := byCluster[k]
+		if !ok {
+			d = &clusterData{ref: ms.ClusterRef}
+			byCluster[k] = d
+		}
+		d.managedLabels = ms.ManagedLabels
+		d.unmanagedLabels = ms.UnManagedLabels
+	}
+
+	for _, d := range byCluster {
+		if err := upsertMigrationClassifierReport(ctx, c, classifier.Name, &d.ref,
+			d.hash, d.deploymentStatus, d.failureMessage,
+			d.managedLabels, d.unmanagedLabels); err != nil {
+			return fmt.Errorf("upserting ClassifierReport for cluster %s/%s: %w",
+				d.ref.Namespace, d.ref.Name, err)
+		}
+	}
+
+	patch := client.MergeFrom(classifier.DeepCopy())
+	classifier.Status.ClusterInfo = nil            //nolint:staticcheck // deprecated, migration only
+	classifier.Status.MachingClusterStatuses = nil //nolint:staticcheck // deprecated, migration only
+	return c.Status().Patch(ctx, classifier, patch)
+}
+
+// upsertMigrationClassifierReport creates or updates the ClassifierReport for the given
+// (classifier, cluster) pair with the migrated status data.
+func upsertMigrationClassifierReport(ctx context.Context, c client.Client,
+	classifierName string, cluster *corev1.ObjectReference,
+	hash []byte, deploymentStatus *libsveltosv1beta1.SveltosFeatureStatus, failureMessage *string,
+	managedLabels []string, unmanagedLabels []libsveltosv1beta1.UnManagedLabel) error {
+
+	clusterType := migrationDeriveClusterType(cluster)
+	reportName := libsveltosv1beta1.GetClassifierReportName(classifierName, cluster.Name, &clusterType)
+
+	existing := &libsveltosv1beta1.ClassifierReport{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: reportName}, existing)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("getting ClassifierReport: %w", err)
+		}
+		existing = &libsveltosv1beta1.ClassifierReport{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Name:      reportName,
+				Labels: libsveltosv1beta1.GetClassifierReportLabels(
+					classifierName, cluster.Name, &clusterType),
+			},
+			Spec: libsveltosv1beta1.ClassifierReportSpec{
+				ClusterNamespace: cluster.Namespace,
+				ClusterName:      cluster.Name,
+				ClusterType:      clusterType,
+				ClassifierName:   classifierName,
+			},
+		}
+		if err := c.Create(ctx, existing); err != nil && !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("creating ClassifierReport: %w", err)
+		}
+		if err := c.Get(ctx, types.NamespacedName{Namespace: cluster.Namespace, Name: reportName}, existing); err != nil {
+			return fmt.Errorf("re-fetching ClassifierReport after create: %w", err)
+		}
+	}
+
+	patch := client.MergeFrom(existing.DeepCopy())
+	existing.Status.Hash = hash
+	existing.Status.DeploymentStatus = deploymentStatus
+	existing.Status.FailureMessage = failureMessage
+	existing.Status.ManagedLabels = managedLabels
+	existing.Status.UnManagedLabels = unmanagedLabels
+	return c.Status().Patch(ctx, existing, patch)
+}
+
+func migrationDeriveClusterType(ref *corev1.ObjectReference) libsveltosv1beta1.ClusterType {
+	if strings.EqualFold(ref.Kind, "SveltosCluster") {
+		return libsveltosv1beta1.ClusterTypeSveltos
+	}
+	return libsveltosv1beta1.ClusterTypeCapi
+}

--- a/pkg/scope/classfier.go
+++ b/pkg/scope/classfier.go
@@ -92,11 +92,17 @@ func (s *ClassifierScope) ControllerName() string {
 }
 
 // SetMachingClusterStatuses sets the MachingClusterStatuses status.
+//
+// Deprecated: MachingClusterStatuses is deprecated. This setter is kept for the migration
+// init-container path; production controller code no longer calls it.
 func (s *ClassifierScope) SetMachingClusterStatuses(matchingClusters []libsveltosv1beta1.MachingClusterStatus) {
 	s.Classifier.Status.MachingClusterStatuses = matchingClusters
 }
 
 // SetClusterInfo sets the ClusterInfo status field.
+//
+// Deprecated: ClusterInfo is deprecated. This setter is kept for the migration
+// init-container path; production controller code no longer calls it.
 func (s *ClassifierScope) SetClusterInfo(clusterInfo []libsveltosv1beta1.ClusterInfo) {
 	s.Classifier.Status.ClusterInfo = clusterInfo
 }

--- a/pkg/scope/classifier_test.go
+++ b/pkg/scope/classifier_test.go
@@ -110,12 +110,12 @@ var _ = Describe("ClassifierScope", func() {
 			Hash:    hash,
 		}
 		scope.SetClusterInfo([]libsveltosv1beta1.ClusterInfo{clusterInfo})
-		Expect(classifier.Status.ClusterInfo).ToNot(BeNil())
-		Expect(len(classifier.Status.ClusterInfo)).To(Equal(1))
-		Expect(classifier.Status.ClusterInfo[0].Cluster.Namespace).To(Equal(clusterNamespace))
-		Expect(classifier.Status.ClusterInfo[0].Cluster.Name).To(Equal(clusterName))
-		Expect(classifier.Status.ClusterInfo[0].Hash).To(Equal(hash))
-		Expect(classifier.Status.ClusterInfo[0].Status).To(Equal(libsveltosv1beta1.SveltosStatusProvisioned))
+		Expect(classifier.Status.ClusterInfo).ToNot(BeNil())                                                  //nolint:staticcheck // deprecated setter test
+		Expect(len(classifier.Status.ClusterInfo)).To(Equal(1))                                               //nolint:staticcheck // deprecated setter test
+		Expect(classifier.Status.ClusterInfo[0].Cluster.Namespace).To(Equal(clusterNamespace))                //nolint:staticcheck // deprecated setter test
+		Expect(classifier.Status.ClusterInfo[0].Cluster.Name).To(Equal(clusterName))                          //nolint:staticcheck // deprecated setter test
+		Expect(classifier.Status.ClusterInfo[0].Hash).To(Equal(hash))                                         //nolint:staticcheck // deprecated setter test
+		Expect(classifier.Status.ClusterInfo[0].Status).To(Equal(libsveltosv1beta1.SveltosStatusProvisioned)) //nolint:staticcheck // deprecated setter test
 	})
 
 	It("SetMatchingClusters sets Classifier.Status.MatchingCluster", func() {
@@ -143,7 +143,7 @@ var _ = Describe("ClassifierScope", func() {
 			},
 		}
 		scope.SetMachingClusterStatuses(machingClusterStatuses)
-		Expect(reflect.DeepEqual(classifier.Status.MachingClusterStatuses, machingClusterStatuses)).To(BeTrue())
+		Expect(reflect.DeepEqual(classifier.Status.MachingClusterStatuses, machingClusterStatuses)).To(BeTrue()) //nolint:staticcheck // deprecated setter test
 	})
 
 })

--- a/test/fv/conflict_test.go
+++ b/test/fv/conflict_test.go
@@ -89,6 +89,13 @@ var _ = Describe("Classifier: update cluster labels", func() {
 
 		verifyClassifierReport(classifier2.Name, true)
 
+		// classifier1 wins the conflict: its labels must appear in ManagedLabels.
+		// classifier2 asked for the same keys but lost: they must appear in UnManagedLabels.
+		verifyClassifierReportManagedLabels(classifier1)
+		verifyClassifierReportUnManagedLabels(classifier2)
+		verifyClassifierStatusEmpty(classifier1.Name)
+		verifyClassifierStatusEmpty(classifier2.Name)
+
 		verifyClusterLabels(classifier1)
 
 		Byf("Deleting classifier instance %s in the management cluster", classifier1.Name)

--- a/test/fv/deploy_test.go
+++ b/test/fv/deploy_test.go
@@ -89,6 +89,8 @@ var _ = Describe("Classifier: deployment", func() {
 			}, timeout, pollingInterval).Should(BeNil())
 		}
 
+		verifyClassfierIsProvisioned(classifier)
+
 		Byf("Deleting classifier instance %s in the management cluster", classifier.Name)
 		currentClassifier := &libsveltosv1beta1.Classifier{}
 		Expect(k8sClient.Get(context.TODO(),

--- a/test/fv/labels_test.go
+++ b/test/fv/labels_test.go
@@ -75,6 +75,8 @@ func verifyFlow(namePrefix string) {
 
 	verifyClassifierReport(classifier.Name, true)
 	verifyClusterLabels(currentClassifier)
+	verifyClassifierReportManagedLabels(currentClassifier)
+	verifyClassifierStatusEmpty(classifier.Name)
 
 	Byf("Changing classifier so cluster is not a match anymore")
 	currentClassifer := &libsveltosv1beta1.Classifier{}

--- a/test/fv/report_match_change_test.go
+++ b/test/fv/report_match_change_test.go
@@ -105,6 +105,8 @@ var _ = Describe("Classifier: update cluster labels", func() {
 		verifyClassifierReport(classifier.Name, true)
 
 		verifyClusterLabels(classifier)
+		verifyClassifierReportManagedLabels(classifier)
+		verifyClassifierStatusEmpty(classifier.Name)
 
 		Byf("Deleting classifier instance %s in the management cluster", classifier.Name)
 		Expect(k8sClient.Get(context.TODO(),

--- a/test/fv/utils_test.go
+++ b/test/fv/utils_test.go
@@ -80,23 +80,19 @@ func verifyClassfierIsProvisioned(classifier *libsveltosv1beta1.Classifier) {
 	Byf("Verifying classifier %s is provisioned on cluster", classifier.Name)
 	currentCuster, err := getCluster()
 	Expect(err).To(BeNil())
+	clusterType := libsveltosv1beta1.ClusterTypeCapi
+	if kindWorkloadCluster.GetKind() == libsveltosv1beta1.SveltosClusterKind {
+		clusterType = libsveltosv1beta1.ClusterTypeSveltos
+	}
+	reportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, currentCuster.GetName(), &clusterType)
 	Eventually(func() bool {
-		currentClassifier := &libsveltosv1beta1.Classifier{}
-		err := k8sClient.Get(context.TODO(),
-			types.NamespacedName{Name: classifier.Name}, currentClassifier)
-		if err != nil {
+		report := &libsveltosv1beta1.ClassifierReport{}
+		if err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: currentCuster.GetNamespace(), Name: reportName}, report); err != nil {
 			return false
 		}
-		for i := range currentClassifier.Status.ClusterInfo {
-			if currentClassifier.Status.ClusterInfo[i].Cluster.Namespace == currentCuster.GetNamespace() &&
-				currentClassifier.Status.ClusterInfo[i].Cluster.Name == currentCuster.GetName() &&
-				currentClassifier.Status.ClusterInfo[i].Status == libsveltosv1beta1.SveltosStatusProvisioned {
-
-				return true
-			}
-		}
-
-		return false
+		return report.Status.DeploymentStatus != nil &&
+			*report.Status.DeploymentStatus == libsveltosv1beta1.SveltosStatusProvisioned
 	}, timeout, pollingInterval).Should(BeTrue())
 }
 
@@ -126,7 +122,93 @@ func verifyClassifierReport(classifierName string, isMatch bool) {
 		err := k8sClient.Get(context.TODO(),
 			types.NamespacedName{Namespace: kindWorkloadCluster.GetNamespace(), Name: classifierReportName},
 			currentClassifierReport)
-		return err == nil && currentClassifierReport.Spec.Match == isMatch
+		if err != nil {
+			return false
+		}
+		if currentClassifierReport.Spec.Match != isMatch {
+			return false
+		}
+		return currentClassifierReport.Status.DeploymentStatus != nil &&
+			*currentClassifierReport.Status.DeploymentStatus == libsveltosv1beta1.SveltosStatusProvisioned
+	}, timeout, pollingInterval).Should(BeTrue())
+}
+
+// verifyClassifierReportManagedLabels checks that ClassifierReport.Status.ManagedLabels
+// contains exactly the label keys from the Classifier spec. This validates the new
+// post-migration storage location for managed-label tracking.
+func verifyClassifierReportManagedLabels(classifier *libsveltosv1beta1.Classifier) {
+	clusterType := libsveltosv1beta1.ClusterTypeCapi
+	if kindWorkloadCluster.GetKind() == libsveltosv1beta1.SveltosClusterKind {
+		clusterType = libsveltosv1beta1.ClusterTypeSveltos
+	}
+	reportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, kindWorkloadCluster.GetName(), &clusterType)
+	Byf("Verifying ClassifierReport %s has ManagedLabels set", reportName)
+	expected := make(map[string]bool, len(classifier.Spec.ClassifierLabels))
+	for i := range classifier.Spec.ClassifierLabels {
+		expected[classifier.Spec.ClassifierLabels[i].Key] = true
+	}
+	Eventually(func() bool {
+		report := &libsveltosv1beta1.ClassifierReport{}
+		if err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: kindWorkloadCluster.GetNamespace(), Name: reportName}, report); err != nil {
+			return false
+		}
+		if len(report.Status.ManagedLabels) != len(expected) {
+			return false
+		}
+		for _, k := range report.Status.ManagedLabels {
+			if !expected[k] {
+				return false
+			}
+		}
+		return true
+	}, timeout, pollingInterval).Should(BeTrue())
+}
+
+// verifyClassifierReportUnManagedLabels checks that ClassifierReport.Status.UnManagedLabels
+// contains exactly the label keys from the Classifier spec. Used to confirm conflict detection.
+func verifyClassifierReportUnManagedLabels(classifier *libsveltosv1beta1.Classifier) {
+	clusterType := libsveltosv1beta1.ClusterTypeCapi
+	if kindWorkloadCluster.GetKind() == libsveltosv1beta1.SveltosClusterKind {
+		clusterType = libsveltosv1beta1.ClusterTypeSveltos
+	}
+	reportName := libsveltosv1beta1.GetClassifierReportName(classifier.Name, kindWorkloadCluster.GetName(), &clusterType)
+	Byf("Verifying ClassifierReport %s has UnManagedLabels set", reportName)
+	expected := make(map[string]bool, len(classifier.Spec.ClassifierLabels))
+	for i := range classifier.Spec.ClassifierLabels {
+		expected[classifier.Spec.ClassifierLabels[i].Key] = true
+	}
+	Eventually(func() bool {
+		report := &libsveltosv1beta1.ClassifierReport{}
+		if err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: kindWorkloadCluster.GetNamespace(), Name: reportName}, report); err != nil {
+			return false
+		}
+		if len(report.Status.UnManagedLabels) != len(expected) {
+			return false
+		}
+		for _, ul := range report.Status.UnManagedLabels {
+			if !expected[ul.Key] {
+				return false
+			}
+		}
+		return true
+	}, timeout, pollingInterval).Should(BeTrue())
+}
+
+// verifyClassifierStatusEmpty confirms that the old Classifier.Status fields
+// (ClusterInfo and MachingClusterStatuses) are not being written to. After the
+// migration these must remain empty — the data lives in ClassifierReport.Status.
+func verifyClassifierStatusEmpty(classifierName string) {
+	Byf("Verifying Classifier %s Status is empty (data lives in ClassifierReport.Status)", classifierName)
+	Eventually(func() bool {
+		classifier := &libsveltosv1beta1.Classifier{}
+		if err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Name: classifierName}, classifier); err != nil {
+			return false
+		}
+		return len(classifier.Status.ClusterInfo) == 0 && //nolint:staticcheck // deprecated fields must stay empty after migration
+			len(classifier.Status.MachingClusterStatuses) == 0 //nolint:staticcheck // deprecated fields must stay empty after migration
 	}, timeout, pollingInterval).Should(BeTrue())
 }
 
@@ -163,13 +245,10 @@ func verifyClusterLabelsAreGone(classifier *libsveltosv1beta1.Classifier) {
 		if err != nil {
 			return false
 		}
-		if currentCuster.GetLabels() == nil {
-			return false
-		}
+		labels := currentCuster.GetLabels()
 		for i := range classifier.Spec.ClassifierLabels {
 			cLabel := classifier.Spec.ClassifierLabels[i]
-			_, ok := currentCuster.GetLabels()[cLabel.Key]
-			if ok {
+			if _, ok := labels[cLabel.Key]; ok {
 				return false
 			}
 		}


### PR DESCRIPTION
Currently, each classifier instance contains list of matching clusters, status for each matching cluster and more.
Since classifier instances are deployed to any managed cluster (there is no cluster selector), this limits the number of clusters Sveltos can manage to 1K to 2K. Above that, the size of a Classifier instance status would reach the max size.

Since for every Classifier instance and managed cluster pair there is a ClassifierReport instance, the per cluster status is moved from the classifier status to the classifierReport status.

This PR also adds an init container which will take care of the migration.