### PR TITLE
(fix): correct Maching → Matching typo in scope setter and test

### DIFF
--- a/pkg/scope/classfier.go
+++ b/pkg/scope/classfier.go
@@ -91,11 +91,11 @@ func (s *ClassifierScope) ControllerName() string {
 	return s.controllerName
 }
 
-// SetMachingClusterStatuses sets the MachingClusterStatuses status.
+// SetMatchingClusterStatuses sets the MachingClusterStatuses status.
 //
 // Deprecated: MachingClusterStatuses is deprecated. This setter is kept for the migration
 // init-container path; production controller code no longer calls it.
-func (s *ClassifierScope) SetMachingClusterStatuses(matchingClusters []libsveltosv1beta1.MachingClusterStatus) {
+func (s *ClassifierScope) SetMatchingClusterStatuses(matchingClusters []libsveltosv1beta1.MachingClusterStatus) {
 	s.Classifier.Status.MachingClusterStatuses = matchingClusters
 }
 

--- a/pkg/scope/classifier_test.go
+++ b/pkg/scope/classifier_test.go
@@ -130,7 +130,7 @@ var _ = Describe("ClassifierScope", func() {
 		Expect(scope).ToNot(BeNil())
 
 		failureMessage := randomString()
-		machingClusterStatuses := []libsveltosv1beta1.MachingClusterStatus{
+		matchingClusterStatuses := []libsveltosv1beta1.MachingClusterStatus{
 			{
 				ClusterRef: corev1.ObjectReference{
 					Namespace: "t-" + randomString(),
@@ -142,8 +142,8 @@ var _ = Describe("ClassifierScope", func() {
 				},
 			},
 		}
-		scope.SetMachingClusterStatuses(machingClusterStatuses)
-		Expect(reflect.DeepEqual(classifier.Status.MachingClusterStatuses, machingClusterStatuses)).To(BeTrue()) //nolint:staticcheck // deprecated setter test
+		scope.SetMatchingClusterStatuses(matchingClusterStatuses)
+		Expect(reflect.DeepEqual(classifier.Status.MachingClusterStatuses, matchingClusterStatuses)).To(BeTrue()) //nolint:staticcheck // deprecated setter test
 	})
 
 })


### PR DESCRIPTION
Renamed the misspelled Go identifier SetMachingClusterStatuses to SetMatchingClusterStatuses in pkg/scope/classfier.go, and updated its test variable and call site accordingly.

The underlying API field MachingClusterStatuses (defined in libsveltos) is already marked deprecated, will be removed in a future release.

Fix #463 