### PR TITLE
opt: Cache managed-cluster clients via libsveltos clustercache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.12.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         - "--shard-key="
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.12.0"
+        - "--version=main"
         - "--registry="
         - "--agent-in-mgmt-cluster=false"
         env:

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,9 +7,9 @@ spec:
   template:
     spec:
       initContainers:
-      - image: docker.io/projectsveltos/classifier:v1.12.0
+      - image: docker.io/projectsveltos/classifier:main
         name: migrate
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/classifier:v1.12.0
+      - image: docker.io/projectsveltos/classifier:main
         name: manager

--- a/controllers/classifier_deployer.go
+++ b/controllers/classifier_deployer.go
@@ -48,6 +48,7 @@ import (
 	"github.com/projectsveltos/classifier/pkg/agent"
 	"github.com/projectsveltos/classifier/pkg/scope"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/libsveltos/lib/crd"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
@@ -274,7 +275,7 @@ func classifierHash(classifier *libsveltosv1beta1.Classifier) []byte {
 // Returns an err if Classifier or associated Sveltos/CAPI Cluster are marked for deletion, or if an
 // error occurs while getting resources.
 func getClassifierAndClusterClient(ctx context.Context, clusterNamespace, clusterName, classifierName string,
-	clusterType libsveltosv1beta1.ClusterType, c client.Client, logger logr.Logger,
+	clusterType libsveltosv1beta1.ClusterType, isPullMode bool, c client.Client, logger logr.Logger,
 ) (*libsveltosv1beta1.Classifier, client.Client, error) {
 
 	// Get Classifier that requested this
@@ -302,7 +303,12 @@ func getClassifierAndClusterClient(ctx context.Context, clusterNamespace, cluste
 		return nil, nil, fmt.Errorf("cluster is marked for deletion")
 	}
 
-	clusterClient, err := clusterproxy.GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
+	// In pull mode there is no direct connection to the managed cluster.
+	if isPullMode {
+		return classifier, nil, nil
+	}
+
+	clusterClient, err := clustercache.GetManager().GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
 		"", "", clusterType, logger)
 	if err != nil {
 		return nil, nil, err
@@ -416,9 +422,13 @@ func updateSecretWithAccessManagementKubeconfig(ctx context.Context, c client.Cl
 	clusterNamespace, clusterName, applicant string, clusterType libsveltosv1beta1.ClusterType,
 	kubeconfig []byte, logger logr.Logger) error {
 
+	// This flow (send-reports mode) deploys sveltos-agent with a pushed kubeconfig and is not
+	// used for pull-mode clusters, which already have Sveltos-applier pre-installed.
+	const isPullMode = false
+
 	// Get Classifier that requested this
 	_, remoteClient, err := getClassifierAndClusterClient(ctx, clusterNamespace, clusterName, applicant,
-		clusterType, c, logger)
+		clusterType, isPullMode, c, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to get classifier and cluster client")
 		return err
@@ -560,7 +570,7 @@ func deploySveltosAgentWithKubeconfigInCluster(ctx context.Context, c client.Cli
 		return err
 	}
 
-	remoteRestConfig, err := clusterproxy.GetKubernetesRestConfig(ctx, c, clusterNamespace, clusterName,
+	remoteRestConfig, err := clustercache.GetManager().GetKubernetesRestConfig(ctx, c, clusterNamespace, clusterName,
 		"", "", clusterType, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to get cluster rest config")
@@ -581,9 +591,10 @@ func deploySveltosAgentWithKubeconfigInCluster(ctx context.Context, c client.Cli
 		return err
 	}
 
-	// Get Classifier that requested this
+	// Get Classifier that requested this. This flow (send-reports mode) is not used for
+	// pull-mode clusters, which already have Sveltos-applier pre-installed.
 	classifier, remoteClient, err := getClassifierAndClusterClient(ctx, clusterNamespace, clusterName, applicant, clusterType,
-		c, logger)
+		false, c, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to get classifier and cluster client")
 		return err
@@ -649,7 +660,7 @@ func deployClassifierInCluster(ctx context.Context, c client.Client,
 
 	// Get Classifier that requested this
 	classifier, remoteClient, err := getClassifierAndClusterClient(ctx, clusterNamespace, clusterName, applicant, clusterType,
-		c, logger)
+		isPullMode, c, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to get classifier and cluster client")
 		return err
@@ -711,7 +722,7 @@ func undeployClassifierFromCluster(ctx context.Context, c client.Client,
 		return undeployClassifierInPullMode(ctx, c, clusterNamespace, clusterName, applicant, logger)
 	}
 
-	remoteClient, err := clusterproxy.GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
+	remoteClient, err := clustercache.GetManager().GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
 		"", "", clusterType, logger)
 	if err != nil {
 		logger.V(logs.LogDebug).Error(err, "failed to get cluster client")
@@ -1108,6 +1119,9 @@ func (r *ClassifierReconciler) proceedProcessingClassifier(ctx context.Context, 
 		if result.Err != nil {
 			errorMessage := result.Err.Error()
 			clusterInfo.FailureMessage = &errorMessage
+
+			clustercache.GetManager().InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+				clusterproxy.GetClusterType(cluster), result.Err)
 		}
 
 		if *deployerStatus == libsveltosv1beta1.SveltosStatusProvisioned {
@@ -1310,7 +1324,7 @@ func deployCRDInPullMode(ctx context.Context, clusterNamespace, clusterName, cla
 func applyCRD(ctx context.Context, clusterNamespace, clusterName string, u *unstructured.Unstructured,
 	clusterType libsveltosv1beta1.ClusterType, logger logr.Logger) error {
 
-	remoteRestConfig, err := clusterproxy.GetKubernetesRestConfig(ctx, getManagementClusterClient(),
+	remoteRestConfig, err := clustercache.GetManager().GetKubernetesRestConfig(ctx, getManagementClusterClient(),
 		clusterNamespace, clusterName, "", "", clusterType, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to get cluster rest config")
@@ -1596,7 +1610,7 @@ func createSveltosAgentNamespaceInManagedCluster(ctx context.Context, c client.C
 	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType, logger logr.Logger) error {
 
 	// Create the projectsveltos namespace in the remote client
-	remoteClient, err := clusterproxy.GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
+	remoteClient, err := clustercache.GetManager().GetKubernetesClient(ctx, c, clusterNamespace, clusterName,
 		"", "", clusterType, logger)
 	if err != nil {
 		logger.V(logs.LogInfo).Error(err, "failed to get cluster rest config")
@@ -1644,7 +1658,7 @@ func deploySveltosAgent(ctx context.Context, c client.Client, clusterNamespace, 
 			classifierName, "do-not-send-reports", clusterType, patches, logger)
 	} else {
 		// Use managed cluster restConfig
-		remoteRestConfig, err := clusterproxy.GetKubernetesRestConfig(ctx, c, clusterNamespace, clusterName,
+		remoteRestConfig, err := clustercache.GetManager().GetKubernetesRestConfig(ctx, c, clusterNamespace, clusterName,
 			"", "", clusterType, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Error(err, "failed to get cluster rest config")

--- a/controllers/classifier_report_collection.go
+++ b/controllers/classifier_report_collection.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clustercache"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/sveltos_upgrade"
@@ -53,7 +54,7 @@ func getClassifierClient(ctx context.Context, clusterNamespace, clusterName stri
 	// ResourceSummary is a Sveltos resource created in managed clusters.
 	// Sveltos resources are always created using cluster-admin so that admin does not need to be
 	// given such permissions.
-	return clusterproxy.GetKubernetesClient(ctx, getManagementClusterClient(),
+	return clustercache.GetManager().GetKubernetesClient(ctx, getManagementClusterClient(),
 		clusterNamespace, clusterName, "", "", clusterType, logger)
 }
 
@@ -411,6 +412,8 @@ func collectClassifierReportsFromCluster(ctx context.Context, c client.Client,
 	clusterClient, err := getClassifierClient(ctx, cluster.Namespace, cluster.Name,
 		clusterproxy.GetClusterType(cluster), logger)
 	if err != nil {
+		clustercache.GetManager().InvalidateOnAuthError(cluster.Namespace, cluster.Name,
+			clusterproxy.GetClusterType(cluster), err)
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.12.0
+	github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/yuin/gopher-lua v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v1.12.0 h1:xQfo/AEh3vVRbfWVazpsgBoRgBG5vzm/sJmXp5YrUEg=
-github.com/projectsveltos/libsveltos v1.12.0/go.mod h1:4/vcbYFCFE8uEGIHmltriAoHxdB8jgS2zI+9gruOfJ4=
+github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087 h1:uOHm6bX9SKfeR6htJHrg5pXK6d2fKmdeRrs9dkIvnkA=
+github.com/projectsveltos/libsveltos v1.12.1-0.20260717183230-6bffa4189087/go.mod h1:4/vcbYFCFE8uEGIHmltriAoHxdB8jgS2zI+9gruOfJ4=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5/go.mod h1:yVL8KQFa9tmcxgwl9nwIMtKgtmIVC1zaFRSCfOwYvPY=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20251212200258-2b3cdcb7c0f5 h1:YbsebwRwTRhV8QacvEAdFqxcxHdeu7JTVtsBovbkgos=

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=true
         command:
@@ -44,7 +44,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/classifier:v1.12.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/classifier:v1.12.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         name: migrate
         resources:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
@@ -44,7 +44,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/classifier:v1.12.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/classifier:v1.12.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         name: migrate
         resources:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -251,7 +251,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
@@ -269,7 +269,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/classifier:v1.12.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -317,7 +317,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/classifier:v1.12.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         name: migrate
         resources:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.go
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.go
@@ -42,7 +42,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.12.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -62,7 +62,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent@sha256:b18a2406827cf94d23720ffb1f445bfb2a9b2e0ac920759be49926f71d10c18d
+        image: docker.io/projectsveltos/sveltos-agent@sha256:77698373182108bfbd6594a752dc49b20b552738ad28af9548cb37de455d6fba
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
@@ -24,7 +24,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.12.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -44,7 +44,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent@sha256:b18a2406827cf94d23720ffb1f445bfb2a9b2e0ac920759be49926f71d10c18d
+        image: docker.io/projectsveltos/sveltos-agent@sha256:77698373182108bfbd6594a752dc49b20b552738ad28af9548cb37de455d6fba
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.go
+++ b/pkg/agent/sveltos-agent.go
@@ -201,7 +201,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.12.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -221,7 +221,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent@sha256:b18a2406827cf94d23720ffb1f445bfb2a9b2e0ac920759be49926f71d10c18d
+        image: docker.io/projectsveltos/sveltos-agent@sha256:77698373182108bfbd6594a752dc49b20b552738ad28af9548cb37de455d6fba
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.yaml
+++ b/pkg/agent/sveltos-agent.yaml
@@ -183,7 +183,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.12.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -203,7 +203,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent@sha256:b18a2406827cf94d23720ffb1f445bfb2a9b2e0ac920759be49926f71d10c18d
+        image: docker.io/projectsveltos/sveltos-agent@sha256:77698373182108bfbd6594a752dc49b20b552738ad28af9548cb37de455d6fba
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-applier.go
+++ b/pkg/agent/sveltos-applier.go
@@ -101,7 +101,7 @@ spec:
         - --cluster-type=
         - --secret-with-kubeconfig=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         command:
         - /manager
         env:
@@ -117,7 +117,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:62900d55e4a3d818150e0bc46cd1657219ba0614960acecc0f3b805baba3c74d
+        image: docker.io/projectsveltos/sveltos-applier@sha256:c7e615f9eeb90362365902a6a38305b87f760c70b3e1a91c251acf2c12fb3c79
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-applier.yaml
+++ b/pkg/agent/sveltos-applier.yaml
@@ -83,7 +83,7 @@ spec:
         - --cluster-type=
         - --secret-with-kubeconfig=
         - --v=5
-        - --version=v1.12.0
+        - --version=main
         command:
         - /manager
         env:
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:62900d55e4a3d818150e0bc46cd1657219ba0614960acecc0f3b805baba3c74d
+        image: docker.io/projectsveltos/sveltos-applier@sha256:c7e615f9eeb90362365902a6a38305b87f760c70b3e1a91c251acf2c12fb3c79
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:62900d55e4a3d818150e0bc46cd1657219ba0614960acecc0f3b805baba3c74d
+        image: docker.io/projectsveltos/sveltos-applier@sha256:c7e615f9eeb90362365902a6a38305b87f760c70b3e1a91c251acf2c12fb3c79
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
classifier previously called clusterproxy.GetKubernetesClient/GetKubernetesRestConfig directly, which builds a new rest.Config, discovery client, and RESTMapper via a live discovery round-trip on every call. Switches to the shared lib/clustercache.GetManager() from libsveltos so these are cached, matching addon-controller, event-manager, and healthcheck-manager. Also calls InvalidateOnAuthError in the deployer-result path so a cached client gets evicted as soon as the API server starts rejecting credentials (401/403) instead of only on TTL expiry or cluster deletion.