### PR TITLE
chore: Advance sveltos-agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.13.0
+TAG ?= main
 
 ## Tool Binaries
 CONTROLLER_GEN := $(TOOLS_BIN_DIR)/controller-gen

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         - "--shard-key="
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.13.0"
+        - "--version=main"
         - "--registry="
         - "--agent-in-mgmt-cluster=false"
         env:

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,9 +7,9 @@ spec:
   template:
     spec:
       initContainers:
-      - image: docker.io/projectsveltos/classifier:v1.13.0
+      - image: docker.io/projectsveltos/classifier:main
         name: migrate
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/classifier:v1.13.0
+      - image: docker.io/projectsveltos/classifier:main
         name: manager

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.13.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=true
         command:
@@ -44,7 +44,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/classifier:v1.13.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/classifier:v1.13.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         name: migrate
         resources:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.13.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
@@ -44,7 +44,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/classifier:v1.13.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -92,7 +92,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/classifier:v1.13.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         name: migrate
         resources:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -251,7 +251,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.13.0
+        - --version=main
         - --registry=
         - --agent-in-mgmt-cluster=false
         command:
@@ -269,7 +269,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/classifier:v1.13.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -317,7 +317,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/classifier:v1.13.0
+        image: docker.io/projectsveltos/classifier:main
         imagePullPolicy: IfNotPresent
         name: migrate
         resources:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.go
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.go
@@ -42,7 +42,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.13.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -62,7 +62,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent@sha256:3f1fb4a8159b5acc6d77d117b8623bbacce0213e32d92ebdc7938d3fd97a3dca
+        image: docker.io/projectsveltos/sveltos-agent@sha256:bc44b8379c76e8859d59508fee024cf3b6798ad16324a0b1118fb64b9599b015
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
+++ b/pkg/agent/sveltos-agent-in-mgmt-cluster.yaml
@@ -24,7 +24,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.13.0
+        - --version=main
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -44,7 +44,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent@sha256:3f1fb4a8159b5acc6d77d117b8623bbacce0213e32d92ebdc7938d3fd97a3dca
+        image: docker.io/projectsveltos/sveltos-agent@sha256:bc44b8379c76e8859d59508fee024cf3b6798ad16324a0b1118fb64b9599b015
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.go
+++ b/pkg/agent/sveltos-agent.go
@@ -201,7 +201,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.13.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -221,7 +221,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent@sha256:3f1fb4a8159b5acc6d77d117b8623bbacce0213e32d92ebdc7938d3fd97a3dca
+        image: docker.io/projectsveltos/sveltos-agent@sha256:bc44b8379c76e8859d59508fee024cf3b6798ad16324a0b1118fb64b9599b015
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/agent/sveltos-agent.yaml
+++ b/pkg/agent/sveltos-agent.yaml
@@ -183,7 +183,7 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
-        - --version=v1.13.0
+        - --version=main
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         - --discard-managed-fields=true
@@ -203,7 +203,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-agent@sha256:3f1fb4a8159b5acc6d77d117b8623bbacce0213e32d92ebdc7938d3fd97a3dca
+        image: docker.io/projectsveltos/sveltos-agent@sha256:bc44b8379c76e8859d59508fee024cf3b6798ad16324a0b1118fb64b9599b015
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
The new sveltos-agent image has an optimization.
Sveltos-agent used to list every Reloader/EventSource/HealthCheck instance in the management cluster when building the list of GVKs to watch, instead of scoping to the ones meant for the cluster this sveltos-agent instance is responsible for.

The new image has a fix for this.